### PR TITLE
fix: prioritize flags above env variables for the team flag default value

### DIFF
--- a/src/flags/team.ts
+++ b/src/flags/team.ts
@@ -9,8 +9,8 @@ export const team = flags.build({
 
   default: ({flags}) => {
     let {HEROKU_ORGANIZATION: org, HEROKU_TEAM: team} = process.env
+    if (flags.org) return flags.org
     if (team) return team
     if (org) return org
-    if (flags.org) return flags.org
-  },
+  }
 })

--- a/test/flags/team.test.ts
+++ b/test/flags/team.test.ts
@@ -92,3 +92,63 @@ describe('optional', () => {
       await TeamCommand.run([])
     })
 })
+
+describe('with flag/env variable priorities', () => {
+  // mimics how team and org flags are setup for v5 plugins
+  // https://github.com/oclif/plugin-legacy/blob/master/src/index.ts
+  // #convertFlagsFromV5
+  class TeamCommand extends Command {
+    static flags = {
+      team: flags.team(),
+      org: flags.team({char: 'o', hidden: true})
+    }
+    async run() {
+      const {flags} = this.parse(this.constructor as any)
+      cli.log(flags.team)
+    }
+  }
+
+  describe('when a team flag is used', function () {
+    fancy
+      .stdout()
+      .env({HEROKU_TEAM: 'team-env'})
+      .env({HEROKU_ORGANIZATION: 'org-env'})
+      .it('takes priority over an org flag and environment variables', async ctx => {
+        await TeamCommand.run(['-t', 'team-flag', '-o', 'org-flag'])
+        expect(ctx.stdout).to.equal('team-flag\n')
+      })
+  })
+
+  describe('when an org flag is used', function () {
+    fancy
+      .stdout()
+      .env({HEROKU_TEAM: 'team-env'})
+      .env({HEROKU_ORGANIZATION: 'org-env'})
+      .it('takes priority over environment variables', async ctx => {
+        await TeamCommand.run(['-o', 'org-flag'])
+        expect(ctx.stdout).to.equal('org-flag\n')
+      })
+  })
+
+  describe('when HEROKU_TEAM is used', function () {
+    fancy
+      .stdout()
+      .env({HEROKU_TEAM: 'team-env'})
+      .env({HEROKU_ORGANIZATION: 'org-env'})
+      .it('takes priority over HEROKU_ORGANIZATION', async ctx => {
+        await TeamCommand.run([])
+        expect(ctx.stdout).to.equal('team-env\n')
+      })
+  })
+
+  describe('when HEROKU_ORGANIZATION is used by itself', function () {
+    fancy
+      .stdout()
+      .env({HEROKU_ORGANIZATION: 'org-env'})
+      .it('is is shown', async ctx => {
+        await TeamCommand.run([])
+        expect(ctx.stdout).to.equal('org-env\n')
+      })
+  })
+
+})


### PR DESCRIPTION
This PR fixes the priority so that the team flag goes in priority of:
1. value passed into team flag

Then from  flag's `default()`:
2. value passed into org flag
3. team environment variable
4. org environment variable

## Important 🚨
* This PR is part of a [bigger PR fix at `heroku/cli`](https://github.com/heroku/cli/pull/1250) and should be merged along with that.
