### PR TITLE
Update login host to auth.heroku.com

### DIFF
--- a/src/login.ts
+++ b/src/login.ts
@@ -29,7 +29,7 @@ interface NetrcEntry {
 const headers = (token: string) => ({headers: {accept: 'application/vnd.heroku+json; version=3', authorization: `Bearer ${token}`}})
 
 export class Login {
-  loginHost = process.env.HEROKU_LOGIN_HOST || 'https://cli-auth.heroku.com'
+  loginHost = process.env.HEROKU_LOGIN_HOST || 'https://auth.heroku.com'
 
   constructor(private readonly config: Config.IConfig, private readonly heroku: APIClient) {}
 


### PR DESCRIPTION
cli-auth.heroku.com is being migrated to auth.heroku.com

https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000007sLacIAE/view