### PR TITLE
feat: Override error message for login device_trust_required

### DIFF
--- a/src/login.ts
+++ b/src/login.ts
@@ -184,7 +184,12 @@ export class Login {
     try {
       auth = await this.createOAuthToken(login!, password, {expiresIn})
     } catch (err) {
-      if (!err.body || err.body.id !== 'two_factor') throw err
+      if (!err.body || err.body.id !== 'two_factor') {
+        if (err.body.id === 'device_trust_required') {
+          err.body.message = 'The interactive flag requires Two-Factor Authentication to be enabled on your account. Please use heroku login.'
+        }
+        throw err
+      }
       let secondFactor = await ux.prompt('Two-factor code', {type: 'mask'})
       auth = await this.createOAuthToken(login!, password, {expiresIn, secondFactor})
     }

--- a/test/login.test.ts
+++ b/test/login.test.ts
@@ -1,0 +1,50 @@
+import * as Config from '@oclif/config'
+import base, {expect} from 'fancy-test'
+import nock from 'nock'
+
+import {Command as CommandBase} from '../src/command'
+
+class Command extends CommandBase {
+  async run() {}
+}
+
+let api: nock.Scope
+beforeEach(() => {
+  api = nock('https://api.heroku.com')
+  api.delete('/oauth/sessions/~').reply(200, {})
+  api.get('/oauth/authorizations').reply(200, [])
+  api.get('/oauth/authorizations/~').reply(200, {})
+})
+
+const test = base
+  .add('config', () => Config.load())
+
+describe('login with interactive', () => {
+  test
+    .it('throws a custom error message body for device_trust_required error', async ctx => {
+      const cmd = new Command([], ctx.config)
+      api
+        .post('/oauth/authorizations')
+        .reply(401, {id: 'device_trust_required', message: 'original error message'})
+
+      await cmd.heroku.login({method: 'interactive'})
+        .catch(e => {
+          expect(e.message).to.contain('The interactive flag requires Two-Factor Authentication')
+          expect(e.message).to.contain('Error ID: device_trust_required')
+        })
+    })
+
+  test
+    .it('sends any other error message body through', async ctx => {
+      const cmd = new Command([], ctx.config)
+      api
+        .post('/oauth/authorizations')
+        .reply(401, {id: 'unauthorized', message: 'original error message'})
+
+      await cmd.heroku.login({method: 'interactive'})
+        .catch(e => {
+          expect(e.message).to.contain('original error message')
+          expect(e.message).to.contain('Error ID: unauthorized')
+        })
+    })
+})


### PR DESCRIPTION
When using Login with interactive, and API returns an error with an id of `device_trust_required`, we should return a custom error body with the text "The interactive flag requires Two-Factor Authentication to be enabled on your account. Please use heroku login."

GUS: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000007t6OqIAI/view

<img width="825" alt="Screen Shot 2020-01-29 at 10 13 46 AM" src="https://user-images.githubusercontent.com/1124585/73375770-ecd7c700-4281-11ea-8e57-106833f627ac.png">