### PR TITLE
fix(login): put url on a separate lines so they can be clicked

### DIFF
--- a/src/login.ts
+++ b/src/login.ts
@@ -267,7 +267,7 @@ export class Login {
 
     // TODO: handle browser
     debug(`opening browser to ${url}`)
-    process.stderr.write(`Opening browser to ${url}\n`)
+    process.stderr.write(`Opening browser to:\n${url}\n`)
     process.stderr.write(color.gray(
       'If the browser fails to open or you’re authenticating on a ' +
       'remote machine, please manually open the URL above in your ' +


### PR DESCRIPTION
This will make it easier to open URLs in terminals that turn the text into a link when they are on a new line.