### PR TITLE
Support calling a local heroku-api

### DIFF
--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -65,7 +65,9 @@ export class APIClient {
     this.preauthPromises = {}
     let self = this as any
     const opts = {
-      host: apiUrl.host,
+      host: apiUrl.hostname,
+      port: apiUrl.port,
+      protocol: apiUrl.protocol,
       headers: {
         accept: 'application/vnd.heroku+json; version=3',
         'user-agent': `heroku-cli/${self.config.version} ${self.config.platform}`,


### PR DESCRIPTION
When trying to use a local heroku api host like
HEROKU_HOST="http://localhost:5001", the api client fails for a number
of reasons. First, protocol is not set, so it defaults to https. Second,
the port is not split out from the hostname so it attempts to lookup the
host using the portname. Third, the port is not passed in to the http
client. This patch fixes all of these issues.