### PR TITLE
don’t attempt login flow when api key is set

### DIFF
--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -123,6 +123,9 @@ export class APIClient {
           if (!(err instanceof deps.HTTP.HTTPError)) throw err
           if (retries > 0) {
             if (opts.retryAuth !== false && err.http.statusCode === 401 && err.body.id === 'unauthorized') {
+              if (process.env.HEROKU_API_KEY) {
+                throw new Error('The token provided to HEROKU_API_KEY is invalid. Please double-check that you have the correct token, or run `heroku login` without HEROKU_API_KEY set.')
+              }
               if (!self.authPromise) self.authPromise = self.login()
               await self.authPromise
               opts.headers.authorization = `Bearer ${self.auth}`

--- a/test/api-client.test.ts
+++ b/test/api-client.test.ts
@@ -75,6 +75,24 @@ describe('api_client', () => {
       })
   })
 
+  describe('with HEROKU_API_KEY', () => {
+    test
+      .it('errors out before attempting a login when HEROKU_API_KEY is set, but invalid', async ctx => {
+        process.env.HEROKU_API_KEY = 'blah'
+        api = nock('https://api.heroku.com', {
+          reqheaders: {Authorization: 'Bearer blah'}
+        })
+        api.get('/account').reply(401, {id: 'unauthorized'})
+
+        const cmd = new Command([], ctx.config)
+        try {
+          await cmd.heroku.get('/account')
+        } catch (error) {
+          expect(error.message).to.equal('The token provided to HEROKU_API_KEY is invalid. Please double-check that you have the correct token, or run `heroku login` without HEROKU_API_KEY set.')
+        }
+      })
+  })
+
   describe('with HEROKU_HOST', () => {
     test
       .it('makes an HTTP request with HEROKU_HOST', async ctx => {


### PR DESCRIPTION
This PR fixes the issue uncovered in https://heroku.support/962316

When a user is providing their own API key using the `HEROKU_API_KEY` environment variable, it's possible for them to get into an awkward state if that key is actually invalid. In the case that it's invalid, the API will return a 401, which will trigger a code path that will ultimately attempt to initiate a new login flow in order for the user to re-authenticate and continue using the CLI.

*However*, the bug here is that the login flow itself checks to see `HEROKU_API_KEY` has been set and immediately bails if it has (e.g. https://github.com/heroku/heroku-cli-command/blob/cfreeman/tweak-login-error-handling/src/login.ts#L43-L44), reporting to the user that they cannot login when `HEROKU_API_KEY` is set, even though the user wasn't attempting to login.

This is confusing UX since it doesn't actually tell the user what the problem is (that their API key is invalid), so this PR remedies the UX quirk by checking if API_KEY is set just before triggering the login flow in the case of a 401 and instead throwing a new error with an appropriate message.