### PR TITLE
Limit Interactive Logins to 30 Days

### DIFF
--- a/test/login.test.ts
+++ b/test/login.test.ts
@@ -47,4 +47,42 @@ describe('login with interactive', () => {
           expect(e.message).to.contain('Error ID: unauthorized')
         })
     })
+
+  test
+    .it('defaults to 30 days login', async ctx => {
+      const cmd = new Command([], ctx.config)
+      api
+        .post('/oauth/authorizations',
+              {scope: ['global'], description: /^Heroku CLI login from .*/, expires_in: 60 * 60 * 24 * 30})
+        .reply(401, {id: 'unauthorized', message: 'not authorized'})
+
+      await cmd.heroku.login({method: 'interactive'})
+        .catch(e => {
+          expect(e.message).to.contain('Error ID: unauthorized')
+        })
+    })
+
+  test
+    .it('allows shorter logins', async ctx => {
+      const cmd = new Command([], ctx.config)
+      api
+        .post('/oauth/authorizations',
+              {scope: ['global'], description: /^Heroku CLI login from .*/, expires_in: 12345})
+        .reply(401, {id: 'unauthorized', message: 'not authorized'})
+
+      await cmd.heroku.login({method: 'interactive', expiresIn: 12345})
+        .catch(e => {
+          expect(e.message).to.contain('Error ID: unauthorized')
+        })
+    })
+
+  test
+    .it('does not allow logins longer than 30 days', async ctx => {
+      const cmd = new Command([], ctx.config)
+
+      await cmd.heroku.login({method: 'interactive', expiresIn: 60 * 60 * 24 * 31})
+        .catch(e => {
+          expect(e.message).to.contain('Cannot set an expiration longer than thirty days')
+        })
+    })
 })


### PR DESCRIPTION
We have [an open PR to front_end_auth that reduces CLI login token expiration to 30 days](https://github.com/heroku/front_end_auth/pull/243). This is to also limit the `--interactive` logins to the same amount.
Since an expiration time can be specified, I've added some code to reject any provided value that is greater than 30 days.

This is a requirement for consistency across Salesforce.
[GUS](https://gus.my.salesforce.com/one/one.app#/alohaRedirect/a07AH000000BD07YAG)