### PR TITLE
fix: oclif core migration remaining packages

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,3 @@
 {
-  "extends": [
-    "oclif",
-    "oclif-typescript"
-  ],
-  "rules": {
-  }
+  "extends": "oclif"
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: lts/*
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/examples/login.ts
+++ b/examples/login.ts
@@ -8,4 +8,4 @@ class LoginCommand extends Command {
 }
 
 (LoginCommand.run([]) as any)
-.catch(require('@oclif/core').Errors.handle)
+  .catch(require('@oclif/core').Errors.handle)

--- a/examples/login.ts
+++ b/examples/login.ts
@@ -8,4 +8,4 @@ class LoginCommand extends Command {
 }
 
 (LoginCommand.run([]) as any)
-.catch(require('@oclif/errors/handle'))
+.catch(require('@oclif/core').Errors.handle)

--- a/examples/logout.ts
+++ b/examples/logout.ts
@@ -8,4 +8,4 @@ class LoginCommand extends Command {
 }
 
 LoginCommand.run([])
-.catch(require('@oclif/errors/handle'))
+  .catch(require('@oclif/errors/handle'))

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@heroku-cli/color": "^1.1.14",
     "@oclif/core": "^1.20.4",
+    "cli-ux": "^6.0.9",
     "debug": "^4.1.1",
     "fs-extra": "^7.0.1",
     "heroku-client": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "proxyquire": "^2.1.0",
     "sinon": "^9.0.3",
     "ts-node": "^8.1.0",
+    "tslint": "^6.1.3",
     "typescript": "^4.8.4"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@heroku-cli/schema": "^1.0.25",
     "@heroku-cli/tslint": "^1.1.4",
+    "@oclif/tslint": "^3.1.1",
     "@types/ansi-styles": "^3.2.1",
     "@types/chai": "^4.1.7",
     "@types/fs-extra": "^5.0.5",
@@ -30,9 +31,6 @@
     "@types/supports-color": "^5.3.0",
     "@types/uuid": "^8.3.0",
     "chai": "^4.2.0",
-    "eslint": "7.32.0",
-    "eslint-config-oclif": "^4.0.0",
-    "eslint-config-oclif-typescript": "^1.0.3",
     "fancy-test": "^1.4.3",
     "mocha": "^6.1.4",
     "nock": "^10.0.6",
@@ -56,9 +54,8 @@
   "repository": "heroku/heroku-cli-command",
   "scripts": {
     "build": "rm -rf lib && tsc",
-    "lint": "eslint . --ext .ts --config .eslintrc",
-    "pretest": "tsc -p test --noEmit",
-    "posttest": "yarn lint",
+    "lint": "tsc -p test --noEmit && tslint -p test -t stylish",
+    "posttest": "yarn run lint",
     "prepublishOnly": "yarn run build",
     "test": "mocha --forbid-only \"test/**/*.test.ts\""
   },

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -1,8 +1,8 @@
-import {Config} from '@oclif/core'
-import { CLIError, warn } from '@oclif/core/lib/errors'
+import {Interfaces} from '@oclif/core'
+import {CLIError, warn} from '@oclif/core/lib/errors'
 import {HTTP, HTTPError, HTTPRequestOptions} from 'http-call'
 import Netrc from 'netrc-parser'
-import * as url from 'url'
+import * as url from 'node:url'
 
 import deps from './deps'
 import {Login} from './login'
@@ -56,7 +56,7 @@ export class APIClient {
   private _twoFactorMutex: Mutex<string> | undefined
   private _auth?: string
 
-  constructor(protected config: Config, public options: IOptions = {}) {
+  constructor(protected config: Interfaces.Config, public options: IOptions = {}) {
     this.config = config
     if (options.required === undefined) options.required = true
     options.preauth = options.preauth !== false

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -1,4 +1,5 @@
-import {Config, Errors, Interfaces} from '@oclif/core'
+import {Config} from '@oclif/core'
+import { CLIError, warn } from '@oclif/core/lib/errors'
 import {HTTP, HTTPError, HTTPRequestOptions} from 'http-call'
 import Netrc from 'netrc-parser'
 import * as url from 'url'
@@ -8,9 +9,6 @@ import {Login} from './login'
 import {Mutex} from './mutex'
 import {RequestId, requestIdHeader} from './request-id'
 import {vars} from './vars'
-
-const {CLIError, warn} = Errors
-const {} = Interfaces
 
 export namespace APIClient {
   export interface Options extends HTTPRequestOptions {
@@ -58,7 +56,7 @@ export class APIClient {
   private _twoFactorMutex: Mutex<string> | undefined
   private _auth?: string
 
-  constructor(protected config: Interfaces.Config, public options: IOptions = {}) {
+  constructor(protected config: Config, public options: IOptions = {}) {
     this.config = config
     if (options.required === undefined) options.required = true
     options.preauth = options.preauth !== false

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -2,7 +2,7 @@ import {Interfaces} from '@oclif/core'
 import {CLIError, warn} from '@oclif/core/lib/errors'
 import {HTTP, HTTPError, HTTPRequestOptions} from 'http-call'
 import Netrc from 'netrc-parser'
-import * as url from 'node:url'
+import * as url from 'url'
 
 import deps from './deps'
 import {Login} from './login'

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -1,14 +1,16 @@
-import * as Config from '@oclif/config'
-import {CLIError, warn} from '@oclif/errors'
+import {Config, Errors, Interfaces} from '@oclif/core'
 import {HTTP, HTTPError, HTTPRequestOptions} from 'http-call'
 import Netrc from 'netrc-parser'
-import * as url from 'node:url'
+import * as url from 'url'
 
 import deps from './deps'
 import {Login} from './login'
 import {Mutex} from './mutex'
 import {RequestId, requestIdHeader} from './request-id'
 import {vars} from './vars'
+
+const {CLIError, warn} = Errors
+const {} = Interfaces
 
 export namespace APIClient {
   export interface Options extends HTTPRequestOptions {
@@ -56,7 +58,7 @@ export class APIClient {
   private _twoFactorMutex: Mutex<string> | undefined
   private _auth?: string
 
-  constructor(protected config: Config.IConfig, public options: IOptions = {}) {
+  constructor(protected config: Interfaces.Config, public options: IOptions = {}) {
     this.config = config
     if (options.required === undefined) options.required = true
     options.preauth = options.preauth !== false
@@ -226,7 +228,7 @@ export class APIClient {
   async logout() {
     try {
       await this._login.logout()
-    } catch (error) {
+    } catch (error: any) {
       warn(error)
     }
 

--- a/src/command.ts
+++ b/src/command.ts
@@ -1,5 +1,5 @@
-import {Command as Base} from '@oclif/command'
-import {deprecate} from 'node:util'
+import {Command as Base} from '@oclif/core'
+import {deprecate} from 'util'
 
 import {APIClient} from './api-client'
 import deps from './deps'

--- a/src/command.ts
+++ b/src/command.ts
@@ -1,5 +1,5 @@
 import {Command as Base} from '@oclif/core'
-import {deprecate} from 'util'
+import {deprecate} from 'node:util'
 
 import {APIClient} from './api-client'
 import deps from './deps'
@@ -7,7 +7,7 @@ import deps from './deps'
 import pjson from '../package.json'
 
 const deprecatedCLI = deprecate(() => {
-  return require('CliUx').cli
+  return require('cli-ux').cli
 }, 'this.out and this.cli is deprecated. Please import "CliUx" from the @oclif/core module directly instead.')
 
 export abstract class Command extends Base {

--- a/src/command.ts
+++ b/src/command.ts
@@ -1,5 +1,5 @@
 import {Command as Base} from '@oclif/core'
-import {deprecate} from 'node:util'
+import {deprecate} from 'util'
 
 import pjson from '../package.json'
 

--- a/src/command.ts
+++ b/src/command.ts
@@ -1,10 +1,10 @@
 import {Command as Base} from '@oclif/core'
 import {deprecate} from 'node:util'
 
+import pjson from '../package.json'
+
 import {APIClient} from './api-client'
 import deps from './deps'
-
-import pjson from '../package.json'
 
 const deprecatedCLI = deprecate(() => {
   return require('cli-ux').cli

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -96,14 +96,14 @@ export const ProcessTypeCompletion: Interfaces.Completion = {
     try {
       const buff = await deps.file.readFile(procfile)
       types = buff
-      .toString()
-      .split('\n')
-      .map((s: string) => {
-        if (!s) return false
-        const m = s.match(/^([\w-]+)/)
-        return m ? m[0] : false
-      })
-      .filter((t: any) => t) as string[]
+        .toString()
+        .split('\n')
+        .map((s: string) => {
+          if (!s) return false
+          const m = s.match(/^([\w-]+)/)
+          return m ? m[0] : false
+        })
+        .filter((t: any) => t) as string[]
     } catch (error) {
       if (error instanceof CLIError && error.code !== 'ENOENT') throw error
     }

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -1,20 +1,20 @@
-import { Completion, Config } from '@oclif/core/lib/interfaces'
-import { CLIError } from '@oclif/core/lib/errors'
-import * as path from 'path'
+import {Interfaces} from '@oclif/core'
+import {CLIError} from '@oclif/core/lib/errors'
+import * as path from 'node:path'
 
 import deps from './deps'
 import {configRemote, getGitRemotes} from './git'
 
 export const oneDay = 60 * 60 * 24
 
-export const herokuGet = async (resource: string, ctx: {config: Config}): Promise<string[]> => {
+export const herokuGet = async (resource: string, ctx: {config: Interfaces.Config}): Promise<string[]> => {
   const heroku = new deps.APIClient(ctx.config)
   let {body: resources} = await heroku.get<any>(`/${resource}`)
   if (typeof resources === 'string') resources = JSON.parse(resources)
   return resources.map((a: any) => a.name).sort()
 }
 
-export const AppCompletion: Completion = {
+export const AppCompletion: Interfaces.Completion = {
   cacheDuration: oneDay,
   options: async ctx => {
     const apps = await herokuGet('apps', ctx)
@@ -22,7 +22,7 @@ export const AppCompletion: Completion = {
   },
 }
 
-export const AppAddonCompletion: Completion = {
+export const AppAddonCompletion: Interfaces.Completion = {
   cacheDuration: oneDay,
   cacheKey: async ctx => {
     return ctx.flags && ctx.flags.app ? `${ctx.flags.app}_addons` : ''
@@ -33,7 +33,7 @@ export const AppAddonCompletion: Completion = {
   },
 }
 
-export const AppDynoCompletion: Completion = {
+export const AppDynoCompletion: Interfaces.Completion = {
   cacheDuration: oneDay,
   cacheKey: async ctx => {
     return ctx.flags && ctx.flags.app ? `${ctx.flags.app}_dynos` : ''
@@ -44,7 +44,7 @@ export const AppDynoCompletion: Completion = {
   },
 }
 
-export const BuildpackCompletion: Completion = {
+export const BuildpackCompletion: Interfaces.Completion = {
   skipCache: true,
 
   options: async () => {
@@ -62,7 +62,7 @@ export const BuildpackCompletion: Completion = {
   },
 }
 
-export const DynoSizeCompletion: Completion = {
+export const DynoSizeCompletion: Interfaces.Completion = {
   cacheDuration: oneDay * 90,
   options: async ctx => {
     const sizes = await herokuGet('dyno-sizes', ctx)
@@ -70,7 +70,7 @@ export const DynoSizeCompletion: Completion = {
   },
 }
 
-export const FileCompletion: Completion = {
+export const FileCompletion: Interfaces.Completion = {
   skipCache: true,
 
   options: async () => {
@@ -79,7 +79,7 @@ export const FileCompletion: Completion = {
   },
 }
 
-export const PipelineCompletion: Completion = {
+export const PipelineCompletion: Interfaces.Completion = {
   cacheDuration: oneDay,
   options: async ctx => {
     const pipelines = await herokuGet('pipelines', ctx)
@@ -87,7 +87,7 @@ export const PipelineCompletion: Completion = {
   },
 }
 
-export const ProcessTypeCompletion: Completion = {
+export const ProcessTypeCompletion: Interfaces.Completion = {
   skipCache: true,
 
   options: async () => {
@@ -112,7 +112,7 @@ export const ProcessTypeCompletion: Completion = {
   },
 }
 
-export const RegionCompletion: Completion = {
+export const RegionCompletion: Interfaces.Completion = {
   cacheDuration: oneDay * 7,
   options: async ctx => {
     const regions = await herokuGet('regions', ctx)
@@ -120,7 +120,7 @@ export const RegionCompletion: Completion = {
   },
 }
 
-export const RemoteCompletion: Completion = {
+export const RemoteCompletion: Interfaces.Completion = {
   skipCache: true,
 
   options: async () => {
@@ -129,7 +129,7 @@ export const RemoteCompletion: Completion = {
   },
 }
 
-export const RoleCompletion: Completion = {
+export const RoleCompletion: Interfaces.Completion = {
   skipCache: true,
 
   options: async () => {
@@ -137,7 +137,7 @@ export const RoleCompletion: Completion = {
   },
 }
 
-export const ScopeCompletion: Completion = {
+export const ScopeCompletion: Interfaces.Completion = {
   skipCache: true,
 
   options: async () => {
@@ -145,7 +145,7 @@ export const ScopeCompletion: Completion = {
   },
 }
 
-export const SpaceCompletion: Completion = {
+export const SpaceCompletion: Interfaces.Completion = {
   cacheDuration: oneDay,
   options: async ctx => {
     const spaces = await herokuGet('spaces', ctx)
@@ -153,7 +153,7 @@ export const SpaceCompletion: Completion = {
   },
 }
 
-export const StackCompletion: Completion = {
+export const StackCompletion: Interfaces.Completion = {
   cacheDuration: oneDay,
   options: async ctx => {
     const stacks = await herokuGet('stacks', ctx)
@@ -161,7 +161,7 @@ export const StackCompletion: Completion = {
   },
 }
 
-export const StageCompletion: Completion = {
+export const StageCompletion: Interfaces.Completion = {
   skipCache: true,
 
   options: async () => {
@@ -169,7 +169,7 @@ export const StageCompletion: Completion = {
   },
 }
 
-export const TeamCompletion: Completion = {
+export const TeamCompletion: Interfaces.Completion = {
   cacheDuration: oneDay,
   options: async ctx => {
     const teams = await herokuGet('teams', ctx)

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -1,6 +1,6 @@
 import {Interfaces} from '@oclif/core'
 import {CLIError} from '@oclif/core/lib/errors'
-import * as path from 'node:path'
+import * as path from 'path'
 
 import deps from './deps'
 import {configRemote, getGitRemotes} from './git'

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,5 +1,5 @@
 // remote
-import CLI = require('cli-ux')
+import core = require('@oclif/core')
 import HTTP = require('http-call')
 import netrc = require('netrc-parser')
 
@@ -12,8 +12,8 @@ import yubikey = require('./yubikey')
 
 export const deps = {
   // remote
-  get cli(): typeof CLI.default {
-    return fetch('cli-ux').default
+  get cli(): typeof core.CliUx.ux {
+    return fetch('@oclif/core').CliUx.ux
   },
   get HTTP(): typeof HTTP {
     return fetch('http-call')

--- a/src/file.ts
+++ b/src/file.ts
@@ -1,5 +1,5 @@
-import * as fs from 'node:fs'
-import {promisify} from 'node:util'
+import * as fs from 'fs'
+import {promisify} from 'util'
 
 let _debug: any
 function debug(...args: any[]) {

--- a/src/flags/app.ts
+++ b/src/flags/app.ts
@@ -1,5 +1,5 @@
 import {Flags} from '@oclif/core'
-import {error, CLIError} from '@oclif/core/lib/errors'
+import {CLIError, error} from '@oclif/core/lib/errors'
 
 import {configRemote, getGitRemotes, IGitRemotes} from '../git'
 

--- a/src/flags/app.ts
+++ b/src/flags/app.ts
@@ -29,7 +29,6 @@ export const app = Flags.custom({
     if (flags.remote && gitRemotes.length === 0) {
       error(`remote ${flags.remote} not found in git remotes`)
     }
-
     if (gitRemotes.length > 1 && options.required) {
       throw new MultipleRemotesError(gitRemotes)
     }

--- a/src/flags/app.ts
+++ b/src/flags/app.ts
@@ -1,10 +1,7 @@
 import { Flags } from '@oclif/core'
 import { error, CLIError } from '@oclif/core/lib/errors'
 
-import {AppCompletion, RemoteCompletion} from '../completions'
 import {configRemote, getGitRemotes, IGitRemotes} from '../git'
-import {Completion} from '@oclif/core/lib/interfaces'
-import {OptionFlagProps, OptionFlag} from '@oclif/core/lib/interfaces/parser'
 
 class MultipleRemotesError extends CLIError {
   constructor(gitRemotes: IGitRemotes[]) {
@@ -21,7 +18,7 @@ class MultipleRemotesError extends CLIError {
   }
 }
 
-const _app = Flags.custom({
+export const app = Flags.custom({
   char: 'a',
   description: 'app to run command against',
   default: async ({options, flags}) => {
@@ -38,10 +35,7 @@ const _app = Flags.custom({
   },
 })
 
-export const app = (blerg:  Partial<OptionFlag<string>> = {}) => _app({...blerg, completion: AppCompletion})
-
 export const remote = Flags.custom({
   char: 'r',
-  // options: [ RemoteCompletion.options ],
   description: 'git remote of app to use'
 })

--- a/src/flags/app.ts
+++ b/src/flags/app.ts
@@ -1,5 +1,5 @@
-import { Flags } from '@oclif/core'
-import { error, CLIError } from '@oclif/core/lib/errors'
+import {Flags} from '@oclif/core'
+import {error, CLIError} from '@oclif/core/lib/errors'
 
 import {configRemote, getGitRemotes, IGitRemotes} from '../git'
 
@@ -29,6 +29,7 @@ export const app = Flags.custom({
     if (flags.remote && gitRemotes.length === 0) {
       error(`remote ${flags.remote} not found in git remotes`)
     }
+
     if (gitRemotes.length > 1 && options.required) {
       throw new MultipleRemotesError(gitRemotes)
     }
@@ -37,5 +38,5 @@ export const app = Flags.custom({
 
 export const remote = Flags.custom({
   char: 'r',
-  description: 'git remote of app to use'
+  description: 'git remote of app to use',
 })

--- a/src/flags/app.ts
+++ b/src/flags/app.ts
@@ -1,6 +1,8 @@
 import {Flags} from '@oclif/core'
 import {CLIError, error} from '@oclif/core/lib/errors'
+import {CompletableOptionFlag} from '@oclif/core/lib/interfaces/parser'
 
+import {AppCompletion, RemoteCompletion} from '../completions'
 import {configRemote, getGitRemotes, IGitRemotes} from '../git'
 
 class MultipleRemotesError extends CLIError {
@@ -18,7 +20,7 @@ class MultipleRemotesError extends CLIError {
   }
 }
 
-export const app = Flags.custom({
+const appWithoutCompletion = Flags.custom({
   char: 'a',
   description: 'app to run command against',
   default: async ({options, flags}) => {
@@ -35,7 +37,13 @@ export const app = Flags.custom({
   },
 })
 
-export const remote = Flags.custom({
+// this approach is used to avoid a breaking change and TS overrides. `completion` will not show as available in the
+// interface, but it didn't in the past.
+export const app = (flagArgs: Partial<CompletableOptionFlag<string>> = {}) => appWithoutCompletion({...flagArgs, completion: AppCompletion})
+
+const remoteWithoutCompletion = Flags.custom({
   char: 'r',
   description: 'git remote of app to use',
 })
+
+export const remote = (flagArgs: Partial<CompletableOptionFlag<string>> = {}) => remoteWithoutCompletion({...flagArgs, completion: RemoteCompletion})

--- a/src/flags/app.ts
+++ b/src/flags/app.ts
@@ -3,6 +3,8 @@ import { error, CLIError } from '@oclif/core/lib/errors'
 
 import {AppCompletion, RemoteCompletion} from '../completions'
 import {configRemote, getGitRemotes, IGitRemotes} from '../git'
+import {Completion} from '@oclif/core/lib/interfaces'
+import {OptionFlagProps, OptionFlag} from '@oclif/core/lib/interfaces/parser'
 
 class MultipleRemotesError extends CLIError {
   constructor(gitRemotes: IGitRemotes[]) {
@@ -19,15 +21,13 @@ class MultipleRemotesError extends CLIError {
   }
 }
 
-export const app = Flags.custom({
+const _app = Flags.custom({
   char: 'a',
-  options: AppCompletion.options,
   description: 'app to run command against',
-  
   default: async ({options, flags}) => {
     const envApp = process.env.HEROKU_APP
     if (envApp) return envApp
-    let gitRemotes = getGitRemotes(flags.remote || configRemote())
+    const gitRemotes = getGitRemotes(flags.remote || configRemote())
     if (gitRemotes.length === 1) return gitRemotes[0].app
     if (flags.remote && gitRemotes.length === 0) {
       error(`remote ${flags.remote} not found in git remotes`)
@@ -38,8 +38,10 @@ export const app = Flags.custom({
   },
 })
 
+export const app = (blerg:  Partial<OptionFlag<string>> = {}) => _app({...blerg, completion: AppCompletion})
+
 export const remote = Flags.custom({
   char: 'r',
-  options: [ RemoteCompletion.options ],
+  // options: [ RemoteCompletion.options ],
   description: 'git remote of app to use'
 })

--- a/src/flags/team.ts
+++ b/src/flags/team.ts
@@ -1,9 +1,11 @@
 import {Flags} from '@oclif/core'
+import {CompletableOptionFlag} from '@oclif/core/lib/interfaces/parser'
 
-export const team = Flags.custom({
+import {TeamCompletion} from '../completions'
+
+const teamWithoutCompletion = Flags.custom({
   char: 't',
   description: 'team to use',
-
   default: async ({flags}) => {
     const {HEROKU_ORGANIZATION: org, HEROKU_TEAM: team} = process.env
     if (flags.org) return flags.org
@@ -11,3 +13,5 @@ export const team = Flags.custom({
     if (org) return org
   },
 })
+
+export const team = (flagArgs: Partial<CompletableOptionFlag<string>> = {}) => teamWithoutCompletion({...flagArgs, completion: TeamCompletion})

--- a/src/flags/team.ts
+++ b/src/flags/team.ts
@@ -4,7 +4,7 @@ import {TeamCompletion} from '../completions'
 
 export const team = Flags.custom({
   char: 't',
-  options: TeamCompletion.options,
+  // options: TeamCompletion.options,
   description: 'team to use',
 
   default: async ({flags}) => {

--- a/src/flags/team.ts
+++ b/src/flags/team.ts
@@ -1,7 +1,5 @@
 import {Flags} from '@oclif/core'
 
-import {TeamCompletion} from '../completions'
-
 export const team = Flags.custom({
   char: 't',
   description: 'team to use',

--- a/src/flags/team.ts
+++ b/src/flags/team.ts
@@ -4,7 +4,6 @@ import {TeamCompletion} from '../completions'
 
 export const team = Flags.custom({
   char: 't',
-  // options: TeamCompletion.options,
   description: 'team to use',
 
   default: async ({flags}) => {

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,4 +1,4 @@
-import { CLIError } from '@oclif/core/lib/errors'
+import {CLIError} from '@oclif/core/lib/errors'
 import {vars} from './vars'
 
 export interface IGitRemote {

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,4 +1,5 @@
 import {CLIError} from '@oclif/core/lib/errors'
+
 import {vars} from './vars'
 
 export interface IGitRemote {
@@ -9,12 +10,12 @@ export interface IGitRemote {
 export class Git {
   get remotes(): IGitRemote[] {
     return this.exec('remote -v')
-    .split('\n')
-    .filter(l => l.endsWith('(fetch)'))
-    .map(l => {
-      const [name, url] = l.split('\t')
-      return {name, url: url.split(' ')[0]}
-    })
+      .split('\n')
+      .filter(l => l.endsWith('(fetch)'))
+      .map(l => {
+        const [name, url] = l.split('\t')
+        return {name, url: url.split(' ')[0]}
+      })
   }
 
   exec(cmd: string): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import * as flags from './flags'
 export {APIClient} from './api-client'
 export {vars} from './vars'
 export {flags}
+export * as completions from './completions'
 
 export {Command}
 export default Command

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,10 @@
 import {Command} from './command'
+import * as completions from './completions'
 import * as flags from './flags'
 
 export {APIClient} from './api-client'
 export {vars} from './vars'
-export {flags}
-export * as completions from './completions'
+export {flags, completions}
 
 export {Command}
 export default Command

--- a/src/login.ts
+++ b/src/login.ts
@@ -64,12 +64,8 @@ export class Login {
       try {
         if (previousEntry && previousEntry.password) await this.logout(previousEntry.password)
       } catch (error) {
-        let message
-        if (error instanceof Error) message = error.message
-        else message = String(error)
+        const message = error instanceof Error ? error.message : String(error)
         ux.warn(message)
-      }
-        ux.warn(error)
       }
 
       let auth

--- a/src/login.ts
+++ b/src/login.ts
@@ -1,6 +1,6 @@
 import color from '@heroku-cli/color'
 import * as Heroku from '@heroku-cli/schema'
-import {Config, CliUx} from '@oclif/core'
+import {CliUx, Interfaces} from '@oclif/core'
 import HTTP from 'http-call'
 import Netrc from 'netrc-parser'
 import open = require('open')
@@ -33,7 +33,7 @@ const headers = (token: string) => ({headers: {accept: 'application/vnd.heroku+j
 export class Login {
   loginHost = process.env.HEROKU_LOGIN_HOST || 'https://cli-auth.heroku.com'
 
-  constructor(private readonly config: Config, private readonly heroku: APIClient) {}
+  constructor(private readonly config: Interfaces.Config, private readonly heroku: APIClient) {}
 
   async login(opts: Login.Options = {}): Promise<void> {
     let loggedIn = false

--- a/src/login.ts
+++ b/src/login.ts
@@ -1,11 +1,12 @@
 import color from '@heroku-cli/color'
 import * as Heroku from '@heroku-cli/schema'
-import * as Config from '@oclif/config'
-import ux from 'cli-ux'
+import {Config, CliUx, Interfaces} from '@oclif/core'
 import HTTP from 'http-call'
 import Netrc from 'netrc-parser'
 import open = require('open')
-import * as os from 'node:os'
+import * as os from 'os'
+
+const {ux} = CliUx
 
 import {APIClient, HerokuAPIError} from './api-client'
 import {vars} from './vars'
@@ -32,7 +33,7 @@ const headers = (token: string) => ({headers: {accept: 'application/vnd.heroku+j
 export class Login {
   loginHost = process.env.HEROKU_LOGIN_HOST || 'https://cli-auth.heroku.com'
 
-  constructor(private readonly config: Config.IConfig, private readonly heroku: APIClient) {}
+  constructor(private readonly config: Interfaces.Config, private readonly heroku: APIClient) {}
 
   async login(opts: Login.Options = {}): Promise<void> {
     let loggedIn = false
@@ -62,7 +63,7 @@ export class Login {
 
       try {
         if (previousEntry && previousEntry.password) await this.logout(previousEntry.password)
-      } catch (error) {
+      } catch (error: any) {
         ux.warn(error)
       }
 
@@ -85,7 +86,7 @@ export class Login {
       }
 
       await this.saveToken(auth)
-    } catch (error) {
+    } catch (error: any) {
       throw new HerokuAPIError(error)
     } finally {
       loggedIn = true
@@ -168,7 +169,7 @@ export class Login {
           headers: {authorization: `Bearer ${urls.token}`},
         })
         return auth
-      } catch (error) {
+      } catch (error: any) {
         if (retries > 0 && error.http && error.http.statusCode > 500) return fetchAuth(retries - 1)
         throw error
       }
@@ -194,7 +195,7 @@ export class Login {
     let auth
     try {
       auth = await this.createOAuthToken(login!, password, {expiresIn})
-    } catch (error) {
+    } catch (error: any) {
       if (error.body && error.body.id === 'device_trust_required') {
         error.body.message = 'The interactive flag requires Two-Factor Authentication to be enabled on your account. Please use heroku login.'
         throw error
@@ -262,7 +263,7 @@ export class Login {
     try {
       const {body: authorization} = await HTTP.get<Heroku.OAuthAuthorization>(`${vars.apiUrl}/oauth/authorizations/~`, headers(this.heroku.auth!))
       return authorization.access_token && authorization.access_token.token
-    } catch (error) {
+    } catch (error: any) {
       if (!error.http) throw error
       if (error.http.statusCode === 404 && error.http.body && error.http.body.id === 'not_found' && error.body.resource === 'authorization') return
       if (error.http.statusCode === 401 && error.http.body && error.http.body.id === 'unauthorized') return

--- a/src/login.ts
+++ b/src/login.ts
@@ -70,20 +70,20 @@ export class Login {
 
       let auth
       switch (input) {
-        case 'b':
-        case 'browser':
-          auth = await this.browser(opts.browser)
-          break
-        case 'i':
-        case 'interactive':
-          auth = await this.interactive(previousEntry && previousEntry.login, opts.expiresIn)
-          break
-        case 's':
-        case 'sso':
-          auth = await this.sso()
-          break
-        default:
-          return this.login(opts)
+      case 'b':
+      case 'browser':
+        auth = await this.browser(opts.browser)
+        break
+      case 'i':
+      case 'interactive':
+        auth = await this.interactive(previousEntry && previousEntry.login, opts.expiresIn)
+        break
+      case 's':
+      case 'sso':
+        auth = await this.sso()
+        break
+      default:
+        return this.login(opts)
       }
 
       await this.saveToken(auth)

--- a/src/login.ts
+++ b/src/login.ts
@@ -1,6 +1,6 @@
 import color from '@heroku-cli/color'
 import * as Heroku from '@heroku-cli/schema'
-import {Config, CliUx, Interfaces} from '@oclif/core'
+import {Config, CliUx} from '@oclif/core'
 import HTTP from 'http-call'
 import Netrc from 'netrc-parser'
 import open = require('open')
@@ -33,7 +33,7 @@ const headers = (token: string) => ({headers: {accept: 'application/vnd.heroku+j
 export class Login {
   loginHost = process.env.HEROKU_LOGIN_HOST || 'https://cli-auth.heroku.com'
 
-  constructor(private readonly config: Interfaces.Config, private readonly heroku: APIClient) {}
+  constructor(private readonly config: Config, private readonly heroku: APIClient) {}
 
   async login(opts: Login.Options = {}): Promise<void> {
     let loggedIn = false

--- a/src/login.ts
+++ b/src/login.ts
@@ -63,7 +63,12 @@ export class Login {
 
       try {
         if (previousEntry && previousEntry.password) await this.logout(previousEntry.password)
-      } catch (error: any) {
+      } catch (error) {
+        let message
+        if (error instanceof Error) message = error.message
+        else message = String(error)
+        ux.warn(message)
+      }
         ux.warn(error)
       }
 

--- a/src/login.ts
+++ b/src/login.ts
@@ -4,7 +4,7 @@ import {Config, CliUx} from '@oclif/core'
 import HTTP from 'http-call'
 import Netrc from 'netrc-parser'
 import open = require('open')
-import * as os from 'os'
+import * as os from 'node:os'
 
 const {ux} = CliUx
 

--- a/src/login.ts
+++ b/src/login.ts
@@ -3,8 +3,8 @@ import * as Heroku from '@heroku-cli/schema'
 import {CliUx, Interfaces} from '@oclif/core'
 import HTTP from 'http-call'
 import Netrc from 'netrc-parser'
-import open = require('open')
 import * as os from 'node:os'
+import open = require('open')
 
 const {ux} = CliUx
 
@@ -100,43 +100,43 @@ export class Login {
     // for SSO logins we delete the session since those do not show up in
     // authorizations because they are created a trusted client
     requests.push(HTTP.delete(`${vars.apiUrl}/oauth/sessions/~`, headers(token))
-    .catch(error => {
-      if (!error.http) throw error
-      if (error.http.statusCode === 404 && error.http.body && error.http.body.id === 'not_found' && error.http.body.resource === 'session') {
+      .catch(error => {
+        if (!error.http) throw error
+        if (error.http.statusCode === 404 && error.http.body && error.http.body.id === 'not_found' && error.http.body.resource === 'session') {
         return
       }
 
-      if (error.http.statusCode === 401 && error.http.body && error.http.body.id === 'unauthorized') {
+        if (error.http.statusCode === 401 && error.http.body && error.http.body.id === 'unauthorized') {
         return
       }
 
-      throw error
-    }))
+        throw error
+      }))
 
     // grab all the authorizations so that we can delete the token they are
     // using in the CLI.  we have to do this rather than delete ~ because
     // the ~ is the API Key, not the authorization that is currently requesting
     requests.push(HTTP.get<Heroku.OAuthAuthorization[]>(`${vars.apiUrl}/oauth/authorizations`, headers(token))
-    .then(async ({body: authorizations}) => {
+      .then(async ({body: authorizations}) => {
       // grab the default authorization because that is the token shown in the
       // dashboard as API Key and they may be using it for something else and we
       // would unwittingly break an integration that they are depending on
-      const d = await this.defaultToken()
-      if (d === token) return
-      return Promise.all(
+        const d = await this.defaultToken()
+        if (d === token) return
+        return Promise.all(
         authorizations
-        .filter(a => a.access_token && a.access_token.token === this.heroku.auth)
-        .map(a => HTTP.delete(`${vars.apiUrl}/oauth/authorizations/${a.id}`, headers(token))),
+          .filter(a => a.access_token && a.access_token.token === this.heroku.auth)
+          .map(a => HTTP.delete(`${vars.apiUrl}/oauth/authorizations/${a.id}`, headers(token))),
       )
-    })
-    .catch(error => {
-      if (!error.http) throw error
-      if (error.http.statusCode === 401 && error.http.body && error.http.body.id === 'unauthorized') {
+      })
+      .catch(error => {
+        if (!error.http) throw error
+        if (error.http.statusCode === 401 && error.http.body && error.http.body.id === 'unauthorized') {
         return []
       }
 
-      throw error
-    }))
+        throw error
+      }))
 
     await Promise.all(requests)
   }

--- a/src/login.ts
+++ b/src/login.ts
@@ -3,8 +3,8 @@ import * as Heroku from '@heroku-cli/schema'
 import {CliUx, Interfaces} from '@oclif/core'
 import HTTP from 'http-call'
 import Netrc from 'netrc-parser'
-import * as os from 'node:os'
 import open = require('open')
+import * as os from 'os'
 
 const {ux} = CliUx
 
@@ -70,20 +70,20 @@ export class Login {
 
       let auth
       switch (input) {
-      case 'b':
-      case 'browser':
-        auth = await this.browser(opts.browser)
-        break
-      case 'i':
-      case 'interactive':
-        auth = await this.interactive(previousEntry && previousEntry.login, opts.expiresIn)
-        break
-      case 's':
-      case 'sso':
-        auth = await this.sso()
-        break
-      default:
-        return this.login(opts)
+        case 'b':
+        case 'browser':
+          auth = await this.browser(opts.browser)
+          break
+        case 'i':
+        case 'interactive':
+          auth = await this.interactive(previousEntry && previousEntry.login, opts.expiresIn)
+          break
+        case 's':
+        case 'sso':
+          auth = await this.sso()
+          break
+        default:
+          return this.login(opts)
       }
 
       await this.saveToken(auth)
@@ -103,12 +103,12 @@ export class Login {
       .catch(error => {
         if (!error.http) throw error
         if (error.http.statusCode === 404 && error.http.body && error.http.body.id === 'not_found' && error.http.body.resource === 'session') {
-        return
-      }
+          return
+        }
 
         if (error.http.statusCode === 401 && error.http.body && error.http.body.id === 'unauthorized') {
-        return
-      }
+          return
+        }
 
         throw error
       }))
@@ -132,8 +132,8 @@ export class Login {
       .catch(error => {
         if (!error.http) throw error
         if (error.http.statusCode === 401 && error.http.body && error.http.body.id === 'unauthorized') {
-        return []
-      }
+          return []
+        }
 
         throw error
       }))

--- a/src/mutex.ts
+++ b/src/mutex.ts
@@ -1,4 +1,4 @@
-export type PromiseResolve<T> = (value: T | PromiseLike<T> | undefined) => void
+export type PromiseResolve<T> = (value: T | PromiseLike<T>) => void
 export type PromiseReject = (reason?: any) => void
 export type Task<T> = () => Promise<T>
 export type Record<T> = [Task<T>, PromiseResolve<T>, PromiseReject]

--- a/src/mutex.ts
+++ b/src/mutex.ts
@@ -1,4 +1,4 @@
-export type PromiseResolve<T> = (value: T | PromiseLike<T>) => void
+export type PromiseResolve<T> = (value: T | PromiseLike<T> | undefined) => void
 export type PromiseReject = (reason?: any) => void
 export type Task<T> = () => Promise<T>
 export type Record<T> = [Task<T>, PromiseResolve<T>, PromiseReject]

--- a/src/mutex.ts
+++ b/src/mutex.ts
@@ -31,9 +31,9 @@ export class Mutex<T> {
     const [task, resolve, reject] = record
 
     return task()
-    .then(resolve, reject)
-    .then(() => {
-      this.dequeue()
-    })
+      .then(resolve, reject)
+      .then(() => {
+        this.dequeue()
+      })
   }
 }

--- a/src/vars.ts
+++ b/src/vars.ts
@@ -1,4 +1,4 @@
-import * as url from 'node:url'
+import * as url from 'url'
 
 export class Vars {
   get host(): string {

--- a/src/vars.ts
+++ b/src/vars.ts
@@ -1,4 +1,4 @@
-import * as url from 'url'
+import * as url from 'node:url'
 
 export class Vars {
   get host(): string {

--- a/test/api-client.test.ts
+++ b/test/api-client.test.ts
@@ -1,8 +1,8 @@
 import {CliUx, Config} from '@oclif/core'
 import base, {expect} from 'fancy-test'
 import nock from 'nock'
-import * as sinon from 'sinon'
 import {resolve} from 'node:path'
+import * as sinon from 'sinon'
 
 import {Command as CommandBase} from '../src/command'
 import {RequestId, requestIdHeader} from '../src/request-id'
@@ -36,7 +36,7 @@ const test = base
 
 describe('api_client', () => {
   test
-  .it('makes an HTTP request', async ctx => {
+    .it('makes an HTTP request', async ctx => {
     api = nock('https://api.heroku.com', {
       reqheaders: {authorization: 'Bearer mypass'},
     })
@@ -49,7 +49,7 @@ describe('api_client', () => {
   })
 
   test
-  .it('can override authorization header', async ctx => {
+    .it('can override authorization header', async ctx => {
     api = nock('https://api.heroku.com', {
       reqheaders: {authorization: 'Bearer myotherpass'},
     })
@@ -62,7 +62,7 @@ describe('api_client', () => {
 
   describe('with HEROKU_HEADERS', () => {
     test
-    .it('makes an HTTP request with HEROKU_HEADERS', async ctx => {
+      .it('makes an HTTP request with HEROKU_HEADERS', async ctx => {
       process.env.HEROKU_HEADERS = '{"x-foo": "bar"}'
       api = nock('https://api.heroku.com', {
         reqheaders: {'x-foo': 'bar'},
@@ -77,7 +77,7 @@ describe('api_client', () => {
 
   describe('with HEROKU_API_KEY', () => {
     test
-    .it('errors out before attempting a login when HEROKU_API_KEY is set, but invalid', async ctx => {
+      .it('errors out before attempting a login when HEROKU_API_KEY is set, but invalid', async ctx => {
       process.env.HEROKU_API_KEY = 'blah'
       api = nock('https://api.heroku.com', {
         reqheaders: {Authorization: 'Bearer blah'},
@@ -99,7 +99,7 @@ describe('api_client', () => {
 
   describe('with HEROKU_HOST', () => {
     test
-    .it('makes an HTTP request with HEROKU_HOST', async ctx => {
+      .it('makes an HTTP request with HEROKU_HOST', async ctx => {
       process.env.HEROKU_HOST = 'http://localhost:5000'
       api = nock('http://localhost:5000')
       api.get('/apps').reply(200, [{name: 'myapp'}])
@@ -111,7 +111,7 @@ describe('api_client', () => {
   })
 
   test
-  .it('2fa no preauth', async ctx => {
+    .it('2fa no preauth', async ctx => {
     api = nock('https://api.heroku.com')
     api.get('/apps').reply(403, {id: 'two_factor'})
     const _api = api as any
@@ -126,7 +126,7 @@ describe('api_client', () => {
   })
 
   test
-  .it('2fa preauth', async ctx => {
+    .it('2fa preauth', async ctx => {
     api = nock('https://api.heroku.com')
     api.get('/apps/myapp').reply(403, {id: 'two_factor', app: {name: 'myapp'}})
     const _api = api as any
@@ -163,7 +163,7 @@ describe('api_client', () => {
     })
 
     test
-    .it('makes requests with a generated request id', async ctx => {
+      .it('makes requests with a generated request id', async ctx => {
       const cmd = new Command([], ctx.config)
 
       generateStub.returns('random-uuid')
@@ -174,7 +174,7 @@ describe('api_client', () => {
     })
 
     test
-    .it('makes requests including previous request ids', async ctx => {
+      .it('makes requests including previous request ids', async ctx => {
       const cmd = new Command([], ctx.config)
       api = nock('https://api.heroku.com').get('/apps').twice().reply(200, [{name: 'myapp'}])
 
@@ -188,7 +188,7 @@ describe('api_client', () => {
     })
 
     test
-    .it('tracks response request ids for subsequent request ids', async ctx => {
+      .it('tracks response request ids for subsequent request ids', async ctx => {
       const cmd = new Command([], ctx.config)
       const existingRequestIds = ['first-existing-request-id', 'second-existing-request-id'].join(',')
       api = nock('https://api.heroku.com').get('/apps').twice().reply(() => [200, JSON.stringify({name: 'myapp'}), {[requestIdHeader]: existingRequestIds}])

--- a/test/api-client.test.ts
+++ b/test/api-client.test.ts
@@ -1,7 +1,8 @@
+// tslint:disable no-http-string
 import {CliUx, Config} from '@oclif/core'
 import base, {expect} from 'fancy-test'
 import nock from 'nock'
-import {resolve} from 'node:path'
+import {resolve} from 'path'
 import * as sinon from 'sinon'
 
 import {Command as CommandBase} from '../src/command'
@@ -37,118 +38,118 @@ const test = base
 describe('api_client', () => {
   test
     .it('makes an HTTP request', async ctx => {
-    api = nock('https://api.heroku.com', {
-      reqheaders: {authorization: 'Bearer mypass'},
-    })
-    api.get('/apps').reply(200, [{name: 'myapp'}])
-
-    const cmd = new Command([], ctx.config)
-    const {body} = await cmd.heroku.get('/apps')
-    expect(body).to.deep.equal([{name: 'myapp'}])
-    // expect(netrc.loadSync).toBeCalled()
-  })
-
-  test
-    .it('can override authorization header', async ctx => {
-    api = nock('https://api.heroku.com', {
-      reqheaders: {authorization: 'Bearer myotherpass'},
-    })
-    api.get('/apps').reply(200, [{name: 'myapp'}])
-
-    const cmd = new Command([], ctx.config)
-    const {body} = await cmd.heroku.get('/apps', {headers: {Authorization: 'Bearer myotherpass'}})
-    expect(body).to.deep.equal([{name: 'myapp'}])
-  })
-
-  describe('with HEROKU_HEADERS', () => {
-    test
-      .it('makes an HTTP request with HEROKU_HEADERS', async ctx => {
-      process.env.HEROKU_HEADERS = '{"x-foo": "bar"}'
       api = nock('https://api.heroku.com', {
-        reqheaders: {'x-foo': 'bar'},
+        reqheaders: {authorization: 'Bearer mypass'},
       })
       api.get('/apps').reply(200, [{name: 'myapp'}])
 
       const cmd = new Command([], ctx.config)
       const {body} = await cmd.heroku.get('/apps')
       expect(body).to.deep.equal([{name: 'myapp'}])
+      // expect(netrc.loadSync).toBeCalled()
     })
+
+  test
+    .it('can override authorization header', async ctx => {
+      api = nock('https://api.heroku.com', {
+        reqheaders: {authorization: 'Bearer myotherpass'},
+      })
+      api.get('/apps').reply(200, [{name: 'myapp'}])
+
+      const cmd = new Command([], ctx.config)
+      const {body} = await cmd.heroku.get('/apps', {headers: {Authorization: 'Bearer myotherpass'}})
+      expect(body).to.deep.equal([{name: 'myapp'}])
+    })
+
+  describe('with HEROKU_HEADERS', () => {
+    test
+      .it('makes an HTTP request with HEROKU_HEADERS', async ctx => {
+        process.env.HEROKU_HEADERS = '{"x-foo": "bar"}'
+        api = nock('https://api.heroku.com', {
+          reqheaders: {'x-foo': 'bar'},
+        })
+        api.get('/apps').reply(200, [{name: 'myapp'}])
+
+        const cmd = new Command([], ctx.config)
+        const {body} = await cmd.heroku.get('/apps')
+        expect(body).to.deep.equal([{name: 'myapp'}])
+      })
   })
 
   describe('with HEROKU_API_KEY', () => {
     test
       .it('errors out before attempting a login when HEROKU_API_KEY is set, but invalid', async ctx => {
-      process.env.HEROKU_API_KEY = 'blah'
-      api = nock('https://api.heroku.com', {
-        reqheaders: {Authorization: 'Bearer blah'},
-      })
-      api.get('/account').reply(401, {id: 'unauthorized'})
+        process.env.HEROKU_API_KEY = 'blah'
+        api = nock('https://api.heroku.com', {
+          reqheaders: {Authorization: 'Bearer blah'},
+        })
+        api.get('/account').reply(401, {id: 'unauthorized'})
 
-      const cmd = new Command([], ctx.config)
-      try {
-        await cmd.heroku.get('/account')
-      } catch (error) {
-        if (error instanceof Error) {
-          expect(error.message).to.equal('The token provided to HEROKU_API_KEY is invalid. Please double-check that you have the correct token, or run `heroku login` without HEROKU_API_KEY set.')
-        } else {
-          throw new TypeError('Unexpected error')
+        const cmd = new Command([], ctx.config)
+        try {
+          await cmd.heroku.get('/account')
+        } catch (error) {
+          if (error instanceof Error) {
+            expect(error.message).to.equal('The token provided to HEROKU_API_KEY is invalid. Please double-check that you have the correct token, or run `heroku login` without HEROKU_API_KEY set.')
+          } else {
+            throw new TypeError('Unexpected error')
+          }
         }
-      }
-    })
+      })
   })
 
   describe('with HEROKU_HOST', () => {
     test
       .it('makes an HTTP request with HEROKU_HOST', async ctx => {
-      process.env.HEROKU_HOST = 'http://localhost:5000'
-      api = nock('http://localhost:5000')
-      api.get('/apps').reply(200, [{name: 'myapp'}])
+        process.env.HEROKU_HOST = 'http://localhost:5000'
+        api = nock('http://localhost:5000')
+        api.get('/apps').reply(200, [{name: 'myapp'}])
 
-      const cmd = new Command([], ctx.config)
-      const {body} = await cmd.heroku.get('/apps')
-      expect(body).to.deep.equal([{name: 'myapp'}])
-    })
+        const cmd = new Command([], ctx.config)
+        const {body} = await cmd.heroku.get('/apps')
+        expect(body).to.deep.equal([{name: 'myapp'}])
+      })
   })
 
   test
     .it('2fa no preauth', async ctx => {
-    api = nock('https://api.heroku.com')
-    api.get('/apps').reply(403, {id: 'two_factor'})
-    const _api = api as any
-    _api.get('/apps').matchHeader('heroku-two-factor-code', '123456').reply(200, [{name: 'myapp'}])
+      api = nock('https://api.heroku.com')
+      api.get('/apps').reply(403, {id: 'two_factor'})
+      const _api = api as any
+      _api.get('/apps').matchHeader('heroku-two-factor-code', '123456').reply(200, [{name: 'myapp'}])
 
-    const cmd = new Command([], ctx.config)
-    Object.defineProperty(cli, 'prompt', {
-      get: () => () => Promise.resolve('123456'),
+      const cmd = new Command([], ctx.config)
+      Object.defineProperty(cli, 'prompt', {
+        get: () => () => Promise.resolve('123456'),
+      })
+      const {body} = await cmd.heroku.get('/apps')
+      expect(body).to.deep.equal([{name: 'myapp'}])
     })
-    const {body} = await cmd.heroku.get('/apps')
-    expect(body).to.deep.equal([{name: 'myapp'}])
-  })
 
   test
     .it('2fa preauth', async ctx => {
-    api = nock('https://api.heroku.com')
-    api.get('/apps/myapp').reply(403, {id: 'two_factor', app: {name: 'myapp'}})
-    const _api = api as any
-    _api.put('/apps/myapp/pre-authorizations').matchHeader('heroku-two-factor-code', '123456').reply(200, {})
-    api.get('/apps/myapp').reply(200, {name: 'myapp'})
-    api.get('/apps/anotherapp').reply(200, {name: 'anotherapp'})
-    api.get('/apps/myapp/config').reply(200, {foo: 'bar'})
-    api.get('/apps/myapp/dynos').reply(200, {web: 1})
+      api = nock('https://api.heroku.com')
+      api.get('/apps/myapp').reply(403, {id: 'two_factor', app: {name: 'myapp'}})
+      const _api = api as any
+      _api.put('/apps/myapp/pre-authorizations').matchHeader('heroku-two-factor-code', '123456').reply(200, {})
+      api.get('/apps/myapp').reply(200, {name: 'myapp'})
+      api.get('/apps/anotherapp').reply(200, {name: 'anotherapp'})
+      api.get('/apps/myapp/config').reply(200, {foo: 'bar'})
+      api.get('/apps/myapp/dynos').reply(200, {web: 1})
 
-    const cmd = new Command([], ctx.config)
-    Object.defineProperty(cli, 'prompt', {
-      get: () => () => Promise.resolve('123456'),
+      const cmd = new Command([], ctx.config)
+      Object.defineProperty(cli, 'prompt', {
+        get: () => () => Promise.resolve('123456'),
+      })
+      const info = cmd.heroku.get('/apps/myapp')
+      const anotherapp = cmd.heroku.get('/apps/anotherapp')
+      const _config = cmd.heroku.get('/apps/myapp/config')
+      const dynos = cmd.heroku.get('/apps/myapp/dynos')
+      expect((await info).body).to.deep.equal({name: 'myapp'})
+      expect((await anotherapp).body).to.deep.equal({name: 'anotherapp'})
+      expect((await _config).body).to.deep.equal({foo: 'bar'})
+      expect((await dynos).body).to.deep.equal({web: 1})
     })
-    const info = cmd.heroku.get('/apps/myapp')
-    const anotherapp = cmd.heroku.get('/apps/anotherapp')
-    const _config = cmd.heroku.get('/apps/myapp/config')
-    const dynos = cmd.heroku.get('/apps/myapp/dynos')
-    expect((await info).body).to.deep.equal({name: 'myapp'})
-    expect((await anotherapp).body).to.deep.equal({name: 'anotherapp'})
-    expect((await _config).body).to.deep.equal({foo: 'bar'})
-    expect((await dynos).body).to.deep.equal({web: 1})
-  })
 
   context('request ids', function () {
     let generateStub: any
@@ -164,42 +165,42 @@ describe('api_client', () => {
 
     test
       .it('makes requests with a generated request id', async ctx => {
-      const cmd = new Command([], ctx.config)
+        const cmd = new Command([], ctx.config)
 
-      generateStub.returns('random-uuid')
-      api = nock('https://api.heroku.com').get('/apps').reply(200, [{name: 'myapp'}])
+        generateStub.returns('random-uuid')
+        api = nock('https://api.heroku.com').get('/apps').reply(200, [{name: 'myapp'}])
 
-      const {request} = await cmd.heroku.get('/apps')
-      expect(request.getHeader(requestIdHeader)).to.deep.equal('random-uuid')
-    })
+        const {request} = await cmd.heroku.get('/apps')
+        expect(request.getHeader(requestIdHeader)).to.deep.equal('random-uuid')
+      })
 
     test
       .it('makes requests including previous request ids', async ctx => {
-      const cmd = new Command([], ctx.config)
-      api = nock('https://api.heroku.com').get('/apps').twice().reply(200, [{name: 'myapp'}])
+        const cmd = new Command([], ctx.config)
+        api = nock('https://api.heroku.com').get('/apps').twice().reply(200, [{name: 'myapp'}])
 
-      generateStub.returns('random-uuid')
-      await cmd.heroku.get('/apps')
+        generateStub.returns('random-uuid')
+        await cmd.heroku.get('/apps')
 
-      generateStub.returns('second-random-uuid')
-      const {request: secondRequest} = await cmd.heroku.get('/apps')
+        generateStub.returns('second-random-uuid')
+        const {request: secondRequest} = await cmd.heroku.get('/apps')
 
-      expect(secondRequest.getHeader(requestIdHeader)).to.deep.equal('second-random-uuid,random-uuid')
-    })
+        expect(secondRequest.getHeader(requestIdHeader)).to.deep.equal('second-random-uuid,random-uuid')
+      })
 
     test
       .it('tracks response request ids for subsequent request ids', async ctx => {
-      const cmd = new Command([], ctx.config)
-      const existingRequestIds = ['first-existing-request-id', 'second-existing-request-id'].join(',')
-      api = nock('https://api.heroku.com').get('/apps').twice().reply(() => [200, JSON.stringify({name: 'myapp'}), {[requestIdHeader]: existingRequestIds}])
+        const cmd = new Command([], ctx.config)
+        const existingRequestIds = ['first-existing-request-id', 'second-existing-request-id'].join(',')
+        api = nock('https://api.heroku.com').get('/apps').twice().reply(() => [200, JSON.stringify({name: 'myapp'}), {[requestIdHeader]: existingRequestIds}])
 
-      generateStub.returns('random-uuid')
-      await cmd.heroku.get('/apps')
+        generateStub.returns('random-uuid')
+        await cmd.heroku.get('/apps')
 
-      generateStub.returns('second-random-uuid')
-      const {request: secondRequest} = await cmd.heroku.get('/apps')
+        generateStub.returns('second-random-uuid')
+        const {request: secondRequest} = await cmd.heroku.get('/apps')
 
-      expect(secondRequest.getHeader(requestIdHeader)).to.deep.equal('second-random-uuid,first-existing-request-id,second-existing-request-id,random-uuid')
-    })
+        expect(secondRequest.getHeader(requestIdHeader)).to.deep.equal('second-random-uuid,first-existing-request-id,second-existing-request-id,random-uuid')
+      })
   })
 })

--- a/test/api-client.test.ts
+++ b/test/api-client.test.ts
@@ -1,12 +1,13 @@
-import {Config, Hook, CliUx} from '@oclif/core'
+import {CliUx, Config} from '@oclif/core'
 import base, {expect} from 'fancy-test'
 import nock from 'nock'
 import * as sinon from 'sinon'
+import {resolve} from 'node:path'
 
 import {Command as CommandBase} from '../src/command'
 import {RequestId, requestIdHeader} from '../src/request-id'
 
-// tslint:disable no-http-string
+const cli = CliUx.ux
 
 class Command extends CommandBase {
   async run() {}
@@ -31,7 +32,7 @@ afterEach(() => {
 })
 
 const test = base
-.add('config', () => Config.load())
+.add('config', new Config({root: resolve(__dirname, '../package.json')}))
 
 describe('api_client', () => {
   test
@@ -87,7 +88,11 @@ describe('api_client', () => {
       try {
         await cmd.heroku.get('/account')
       } catch (error) {
-        expect(error.message).to.equal('The token provided to HEROKU_API_KEY is invalid. Please double-check that you have the correct token, or run `heroku login` without HEROKU_API_KEY set.')
+        if (error instanceof Error) {
+          expect(error.message).to.equal('The token provided to HEROKU_API_KEY is invalid. Please double-check that you have the correct token, or run `heroku login` without HEROKU_API_KEY set.')
+        } else {
+          throw new TypeError('Unexpected error')
+        }
       }
     })
   })

--- a/test/command.test.ts
+++ b/test/command.test.ts
@@ -1,11 +1,12 @@
 import {Config} from '@oclif/core'
 import base, {expect} from 'fancy-test'
+import {resolve} from 'path'
 
 import {Command} from '../src/command'
 import * as flags from '../src/flags'
 
 const test = base
-.add('config', () => Config.load())
+.add('config', new Config({root: resolve(__dirname, '../package.json')}))
 
 class MyCommand extends Command {
   async run() {}
@@ -27,7 +28,7 @@ describe('command', () => {
 
   test
   .it('has heroku clients', async ctx => {
-    const cmd = new MyCommand([], ctx.config as Config)
+    const cmd = new MyCommand([], ctx.config)
     expect(cmd.heroku).to.be.ok
     expect(cmd.legacyHerokuClient).to.be.ok
   })

--- a/test/command.test.ts
+++ b/test/command.test.ts
@@ -1,6 +1,6 @@
 import {Config} from '@oclif/core'
 import base, {expect} from 'fancy-test'
-import {resolve} from 'path'
+import {resolve} from 'node:path'
 
 import {Command} from '../src/command'
 import * as flags from '../src/flags'

--- a/test/command.test.ts
+++ b/test/command.test.ts
@@ -27,7 +27,7 @@ describe('command', () => {
   })
 
   test
-  .it('has heroku clients', async ctx => {
+    .it('has heroku clients', async ctx => {
     const cmd = new MyCommand([], ctx.config)
     expect(cmd.heroku).to.be.ok
     expect(cmd.legacyHerokuClient).to.be.ok

--- a/test/command.test.ts
+++ b/test/command.test.ts
@@ -1,6 +1,6 @@
 import {Config} from '@oclif/core'
 import base, {expect} from 'fancy-test'
-import {resolve} from 'node:path'
+import {resolve} from 'path'
 
 import {Command} from '../src/command'
 import * as flags from '../src/flags'
@@ -28,8 +28,8 @@ describe('command', () => {
 
   test
     .it('has heroku clients', async ctx => {
-    const cmd = new MyCommand([], ctx.config)
-    expect(cmd.heroku).to.be.ok
-    expect(cmd.legacyHerokuClient).to.be.ok
-  })
+      const cmd = new MyCommand([], ctx.config)
+      expect(cmd.heroku).to.be.ok
+      expect(cmd.legacyHerokuClient).to.be.ok
+    })
 })

--- a/test/command.test.ts
+++ b/test/command.test.ts
@@ -1,4 +1,4 @@
-import {Config, Interfaces} from '@oclif/core'
+import {Config} from '@oclif/core'
 import base, {expect} from 'fancy-test'
 
 import {Command} from '../src/command'
@@ -27,7 +27,7 @@ describe('command', () => {
 
   test
   .it('has heroku clients', async ctx => {
-    const cmd = new MyCommand([], ctx.config)
+    const cmd = new MyCommand([], ctx.config as Config)
     expect(cmd.heroku).to.be.ok
     expect(cmd.legacyHerokuClient).to.be.ok
   })

--- a/test/flags/app.test.ts
+++ b/test/flags/app.test.ts
@@ -1,4 +1,4 @@
-import * as Config from '@oclif/config'
+import {Config} from '@oclif/core'
 import {expect, fancy} from 'fancy-test'
 import nock from 'nock'
 
@@ -31,7 +31,7 @@ describe('required', () => {
   it('has an app', async () => {
     await class extends Command {
       async run() {
-        const {flags} = this.parse(Command)
+        const {flags} = await this.parse(Command)
         expect(flags.app).to.equal('myapp')
       }
     }.run(['--app', 'myapp'])
@@ -45,7 +45,7 @@ describe('required', () => {
     ])
     await class extends Command {
       async run() {
-        const {flags} = this.parse(Command)
+        const {flags} = await this.parse(Command)
         expect(flags.app).to.equal('myapp-staging')
       }
     }.run(['--remote', 'staging'])
@@ -94,7 +94,7 @@ describe('required', () => {
       } as any
 
       async run() {
-        const {flags} = this.parse(Command)
+        const {flags} = await this.parse(Command)
         expect(flags.app).to.be.undefined
       }
     }.run([])
@@ -108,7 +108,7 @@ describe('required', () => {
       } as any
 
       async run() {
-        const {flags} = this.parse(Command)
+        const {flags} = await this.parse(Command)
         expect(flags.app).to.equal('myapp')
       }
     }.run([])
@@ -127,7 +127,7 @@ describe('optional', () => {
       } as any
 
       async run() {
-        const {flags} = this.parse(Command)
+        const {flags} = await this.parse(Command)
         expect(flags.app).to.be.undefined
       }
     }.run([])
@@ -140,7 +140,7 @@ describe('optional', () => {
       } as any
 
       async run() {
-        const {flags} = this.parse(Command)
+        const {flags} = await this.parse(Command)
         expect(flags.app).to.be.undefined
       }
     }.run([])

--- a/test/flags/app.test.ts
+++ b/test/flags/app.test.ts
@@ -3,7 +3,6 @@ import {expect, fancy} from 'fancy-test'
 import nock from 'nock'
 
 import {Command as Base} from '../../src'
-import {AppCompletion} from '../../src/completions'
 import * as flags from '../../src/flags'
 import {Git} from '../../src/git'
 
@@ -155,14 +154,23 @@ describe('optional', () => {
 })
 
 describe('completion', () => {
+  class Command extends Base {
+    // options passed to flags.app below are to confirm typing and nothing else
+    static flags = {app: flags.app({required: true, multiple: true})}
+    async run() {}
+  }
+
   it('cacheDuration defaults to 1 day', () => {
-    const duration = AppCompletion.cacheDuration
+    // @ts-ignore
+    const duration = Command.flags.app.completion.cacheDuration
     expect(duration).to.equal(86_400)
   })
 
   it('options returns all the apps', async () => {
+    // @ts-ignore
+    const completion = Command.flags.app.completion
     api.get('/apps').reply(200, [{id: 1, name: 'foo'}, {id: 2, name: 'bar'}])
-    const options = await AppCompletion.options({config: await Config.load()})
+    const options = await completion.options({config: await Config.load()})
     expect(options).to.deep.equal(['bar', 'foo'])
   })
 })

--- a/test/flags/app.test.ts
+++ b/test/flags/app.test.ts
@@ -40,17 +40,17 @@ describe('required', () => {
 
   fancy
     .it('gets app from --remote flag', async () => {
-    withRemotes([
+      withRemotes([
       {name: 'staging', url: 'https://git.heroku.com/myapp-staging.git'},
       {name: 'production', url: 'https://git.heroku.com/myapp-production.git'},
-    ])
-    await class extends Command {
-      async run() {
-        const {flags} = await this.parse(Command)
-        expect(flags.app).to.equal('myapp-staging')
-      }
-    }.run(['--remote', 'staging'])
-  })
+      ])
+      await class extends Command {
+        async run() {
+          const {flags} = await this.parse(Command)
+          expect(flags.app).to.equal('myapp-staging')
+        }
+      }.run(['--remote', 'staging'])
+    })
 
   it('errors if --remote not found', async () => {
     withRemotes([
@@ -155,21 +155,14 @@ describe('optional', () => {
 })
 
 describe('completion', () => {
-  class Command extends Base {
-    static flags = {app: flags.app({})}
-    async run() {}
-  }
-
   it('cacheDuration defaults to 1 day', () => {
-    const completion = AppCompletion
-    const duration = completion.cacheDuration
+    const duration = AppCompletion.cacheDuration
     expect(duration).to.equal(86_400)
   })
 
   it('options returns all the apps', async () => {
-    const completion = AppCompletion
     api.get('/apps').reply(200, [{id: 1, name: 'foo'}, {id: 2, name: 'bar'}])
-    const options = await completion.options({config: await Config.load()})
+    const options = await AppCompletion.options({config: await Config.load()})
     expect(options).to.deep.equal(['bar', 'foo'])
   })
 })

--- a/test/flags/app.test.ts
+++ b/test/flags/app.test.ts
@@ -3,9 +3,9 @@ import {expect, fancy} from 'fancy-test'
 import nock from 'nock'
 
 import {Command as Base} from '../../src'
+import {AppCompletion} from '../../src/completions'
 import * as flags from '../../src/flags'
 import {Git} from '../../src/git'
-import {AppCompletion} from '../../src/completions'
 
 let api: nock.Scope
 const origRemotes = Object.getOwnPropertyDescriptor(Git.prototype, 'remotes')
@@ -39,7 +39,7 @@ describe('required', () => {
   })
 
   fancy
-  .it('gets app from --remote flag', async () => {
+    .it('gets app from --remote flag', async () => {
     withRemotes([
       {name: 'staging', url: 'https://git.heroku.com/myapp-staging.git'},
       {name: 'production', url: 'https://git.heroku.com/myapp-production.git'},

--- a/test/flags/org.test.ts
+++ b/test/flags/org.test.ts
@@ -1,4 +1,4 @@
-import {Command, CliUx} from '@oclif/core'
+import {CliUx, Command} from '@oclif/core'
 import {expect, fancy} from 'fancy-test'
 
 import * as flags from '../../src/flags'
@@ -15,14 +15,14 @@ describe('required', () => {
   }
 
   fancy
-  .stdout()
-  .it('has an org', async ctx => {
+    .stdout()
+    .it('has an org', async ctx => {
     await OrgCommand.run(['--org', 'myorg'])
     expect(ctx.stdout).to.equal('myorg\n')
   })
 
   fancy
-  .it('errors with no org', async (_, done) => {
+    .it('errors with no org', async (_, done) => {
     try {
       await OrgCommand.run([])
     } catch (error) {
@@ -47,26 +47,26 @@ describe('optional', () => {
   }
 
   fancy
-  .stdout()
-  .it('--org', async ctx => {
+    .stdout()
+    .it('--org', async ctx => {
     await OrgCommand.run(['--org', 'myorg'])
     expect(ctx.stdout).to.equal('myorg\n')
   })
 
   fancy
-  .stdout()
-  .it('-o', async ctx => {
+    .stdout()
+    .it('-o', async ctx => {
     await OrgCommand.run(['-o', 'myorg'])
     expect(ctx.stdout).to.equal('myorg\n')
   })
 
   fancy
-  .stdout()
-  .env({HEROKU_ORGANIZATION: 'myorg'})
-  .it('reads HEROKU_ORGANIZATION', async ctx => {
+    .stdout()
+    .env({HEROKU_ORGANIZATION: 'myorg'})
+    .it('reads HEROKU_ORGANIZATION', async ctx => {
     class OrgCommand extends Command {
-        static flags = {org: flags.org()}
-        async run() {
+      static flags = {org: flags.org()}
+      async run() {
           const {flags} = await this.parse(this.constructor as any)
           cli.log(flags.org)
         }
@@ -81,8 +81,8 @@ describe('optional', () => {
   })
 
   fancy
-  .stdout()
-  .it('does not error when org is not specified', async () => {
+    .stdout()
+    .it('does not error when org is not specified', async () => {
     await OrgCommand.run([])
   })
 })

--- a/test/flags/org.test.ts
+++ b/test/flags/org.test.ts
@@ -29,7 +29,7 @@ describe('required', () => {
       if (error instanceof Error) {
         expect(error.message).to.contain('Missing required flag org')
       } else {
-        throw new TypeError('Unhandled error state')
+        throw new TypeError('Unexpected error')
       }
 
       done()

--- a/test/flags/org.test.ts
+++ b/test/flags/org.test.ts
@@ -1,14 +1,15 @@
-import {Command} from '@oclif/command'
-import {cli} from 'cli-ux'
+import {Command, CliUx} from '@oclif/core'
 import {expect, fancy} from 'fancy-test'
 
 import * as flags from '../../src/flags'
+
+const cli = CliUx.ux
 
 describe('required', () => {
   class OrgCommand extends Command {
     static flags = {org: flags.org({required: true})}
     async run() {
-      const {flags} = this.parse(this.constructor as any)
+      const {flags} = await this.parse(this.constructor as any)
       cli.log(flags.org)
     }
   }
@@ -25,7 +26,12 @@ describe('required', () => {
     try {
       await OrgCommand.run([])
     } catch (error) {
-      expect(error.message).to.contain('Missing required flag:\n -o, --org')
+      if (error instanceof Error) {
+        expect(error.message).to.contain('Missing required flag org')
+      } else {
+        throw new TypeError('Unhandled error state')
+      }
+
       done()
     }
   })
@@ -35,7 +41,7 @@ describe('optional', () => {
   class OrgCommand extends Command {
     static flags = {org: flags.org()}
     async run() {
-      const {flags} = this.parse(this.constructor as any)
+      const {flags} = await this.parse(this.constructor as any)
       cli.log(flags.org)
     }
   }
@@ -61,7 +67,7 @@ describe('optional', () => {
     class OrgCommand extends Command {
         static flags = {org: flags.org()}
         async run() {
-          const {flags} = this.parse(this.constructor as any)
+          const {flags} = await this.parse(this.constructor as any)
           cli.log(flags.org)
         }
     }

--- a/test/flags/org.test.ts
+++ b/test/flags/org.test.ts
@@ -17,24 +17,24 @@ describe('required', () => {
   fancy
     .stdout()
     .it('has an org', async ctx => {
-    await OrgCommand.run(['--org', 'myorg'])
-    expect(ctx.stdout).to.equal('myorg\n')
-  })
+      await OrgCommand.run(['--org', 'myorg'])
+      expect(ctx.stdout).to.equal('myorg\n')
+    })
 
   fancy
     .it('errors with no org', async (_, done) => {
-    try {
-      await OrgCommand.run([])
-    } catch (error) {
-      if (error instanceof Error) {
-        expect(error.message).to.contain('Missing required flag org')
-      } else {
-        throw new TypeError('Unexpected error')
-      }
+      try {
+        await OrgCommand.run([])
+      } catch (error) {
+        if (error instanceof Error) {
+          expect(error.message).to.contain('Missing required flag org')
+        } else {
+          throw new TypeError('Unexpected error')
+        }
 
-      done()
-    }
-  })
+        done()
+      }
+    })
 })
 
 describe('optional', () => {
@@ -49,32 +49,32 @@ describe('optional', () => {
   fancy
     .stdout()
     .it('--org', async ctx => {
-    await OrgCommand.run(['--org', 'myorg'])
-    expect(ctx.stdout).to.equal('myorg\n')
-  })
+      await OrgCommand.run(['--org', 'myorg'])
+      expect(ctx.stdout).to.equal('myorg\n')
+    })
 
   fancy
     .stdout()
     .it('-o', async ctx => {
-    await OrgCommand.run(['-o', 'myorg'])
-    expect(ctx.stdout).to.equal('myorg\n')
-  })
+      await OrgCommand.run(['-o', 'myorg'])
+      expect(ctx.stdout).to.equal('myorg\n')
+    })
 
   fancy
     .stdout()
     .env({HEROKU_ORGANIZATION: 'myorg'})
     .it('reads HEROKU_ORGANIZATION', async ctx => {
-    class OrgCommand extends Command {
-      static flags = {org: flags.org()}
-      async run() {
+      class OrgCommand extends Command {
+        static flags = {org: flags.org()}
+        async run() {
           const {flags} = await this.parse(this.constructor as any)
           cli.log(flags.org)
         }
-    }
+      }
 
-    await OrgCommand.run([])
-    expect(ctx.stdout).to.equal('myorg\n')
-  })
+      await OrgCommand.run([])
+      expect(ctx.stdout).to.equal('myorg\n')
+    })
 
   it('is hidden by default', async () => {
     expect(flags.org().hidden).to.be.ok
@@ -83,6 +83,6 @@ describe('optional', () => {
   fancy
     .stdout()
     .it('does not error when org is not specified', async () => {
-    await OrgCommand.run([])
-  })
+      await OrgCommand.run([])
+    })
 })

--- a/test/flags/pipeline.test.ts
+++ b/test/flags/pipeline.test.ts
@@ -14,15 +14,15 @@ describe('required', () => {
   }
 
   fancy
-  .stdout()
-  .it('has a pipeline', async ctx => {
+    .stdout()
+    .it('has a pipeline', async ctx => {
     await PipelineCommand.run(['--pipeline', 'mypipeline'])
     expect(ctx.stdout).to.equal('mypipeline\n')
   })
 
   fancy
-  .stdout()
-  .it('errors with no pipeline', async (_, done) => {
+    .stdout()
+    .it('errors with no pipeline', async (_, done) => {
     try {
       await PipelineCommand.run([])
     } catch (error) {
@@ -49,28 +49,28 @@ describe('optional', () => {
   }
 
   fancy
-  .stdout()
-  .it('--pipeline', async ctx => {
+    .stdout()
+    .it('--pipeline', async ctx => {
     await PipelineCommand.run(['--pipeline', 'mypipeline'])
     expect(ctx.stdout).to.equal('mypipeline\n')
   })
 
   fancy
-  .stdout()
-  .it('-p', async ctx => {
+    .stdout()
+    .it('-p', async ctx => {
     await PipelineCommand.run(['-p', 'mypipeline'])
     expect(ctx.stdout).to.equal('mypipeline\n')
   })
 
   fancy
-  .stdout()
-  .it('is not hidden by default', async () => {
+    .stdout()
+    .it('is not hidden by default', async () => {
     expect(flags.pipeline().hidden).to.not.be.ok
   })
 
   fancy
-  .stdout()
-  .it('does not error when pipeline is not specified', async () => {
+    .stdout()
+    .it('does not error when pipeline is not specified', async () => {
     await PipelineCommand.run([])
   })
 })

--- a/test/flags/pipeline.test.ts
+++ b/test/flags/pipeline.test.ts
@@ -29,7 +29,7 @@ describe('required', () => {
       if (error instanceof Error) {
         expect(error.message).to.contain('Missing required flag pipeline')
       } else {
-        throw new TypeError('Unhandled error state')
+        throw new TypeError('Unexpected error')
       }
 
       done()

--- a/test/flags/pipeline.test.ts
+++ b/test/flags/pipeline.test.ts
@@ -1,4 +1,4 @@
-import {Command} from '@oclif/command'
+import {Command} from '@oclif/core'
 import {expect, fancy} from 'fancy-test'
 
 import * as flags from '../../src/flags'
@@ -8,7 +8,7 @@ describe('required', () => {
     static flags = {pipeline: flags.pipeline({required: true})}
 
     async run() {
-      const {flags} = this.parse(this.constructor as any)
+      const {flags} = await this.parse(this.constructor as any)
       this.log(flags.pipeline)
     }
   }
@@ -26,7 +26,12 @@ describe('required', () => {
     try {
       await PipelineCommand.run([])
     } catch (error) {
-      expect(error.message).to.contain('Missing required flag:\n -p, --pipeline PIPELINE')
+      if (error instanceof Error) {
+        expect(error.message).to.contain('Missing required flag pipeline')
+      } else {
+        throw new TypeError('Unhandled error state')
+      }
+
       done()
     }
   })
@@ -38,7 +43,7 @@ describe('optional', () => {
     pipeline?: string
 
     async run() {
-      const {flags} = this.parse(this.constructor as any)
+      const {flags} = await this.parse(this.constructor as any)
       this.log(flags.pipeline)
     }
   }

--- a/test/flags/pipeline.test.ts
+++ b/test/flags/pipeline.test.ts
@@ -16,25 +16,25 @@ describe('required', () => {
   fancy
     .stdout()
     .it('has a pipeline', async ctx => {
-    await PipelineCommand.run(['--pipeline', 'mypipeline'])
-    expect(ctx.stdout).to.equal('mypipeline\n')
-  })
+      await PipelineCommand.run(['--pipeline', 'mypipeline'])
+      expect(ctx.stdout).to.equal('mypipeline\n')
+    })
 
   fancy
     .stdout()
     .it('errors with no pipeline', async (_, done) => {
-    try {
-      await PipelineCommand.run([])
-    } catch (error) {
-      if (error instanceof Error) {
-        expect(error.message).to.contain('Missing required flag pipeline')
-      } else {
-        throw new TypeError('Unexpected error')
-      }
+      try {
+        await PipelineCommand.run([])
+      } catch (error) {
+        if (error instanceof Error) {
+          expect(error.message).to.contain('Missing required flag pipeline')
+        } else {
+          throw new TypeError('Unexpected error')
+        }
 
-      done()
-    }
-  })
+        done()
+      }
+    })
 })
 
 describe('optional', () => {
@@ -51,26 +51,26 @@ describe('optional', () => {
   fancy
     .stdout()
     .it('--pipeline', async ctx => {
-    await PipelineCommand.run(['--pipeline', 'mypipeline'])
-    expect(ctx.stdout).to.equal('mypipeline\n')
-  })
+      await PipelineCommand.run(['--pipeline', 'mypipeline'])
+      expect(ctx.stdout).to.equal('mypipeline\n')
+    })
 
   fancy
     .stdout()
     .it('-p', async ctx => {
-    await PipelineCommand.run(['-p', 'mypipeline'])
-    expect(ctx.stdout).to.equal('mypipeline\n')
-  })
+      await PipelineCommand.run(['-p', 'mypipeline'])
+      expect(ctx.stdout).to.equal('mypipeline\n')
+    })
 
   fancy
     .stdout()
     .it('is not hidden by default', async () => {
-    expect(flags.pipeline().hidden).to.not.be.ok
-  })
+      expect(flags.pipeline().hidden).to.not.be.ok
+    })
 
   fancy
     .stdout()
     .it('does not error when pipeline is not specified', async () => {
-    await PipelineCommand.run([])
-  })
+      await PipelineCommand.run([])
+    })
 })

--- a/test/flags/team.test.ts
+++ b/test/flags/team.test.ts
@@ -17,24 +17,24 @@ describe('required', () => {
   fancy
     .stdout()
     .it('has an team', async ctx => {
-    await TeamCommand.run(['--team', 'myteam'])
-    expect(ctx.stdout).to.equal('myteam\n')
-  })
+      await TeamCommand.run(['--team', 'myteam'])
+      expect(ctx.stdout).to.equal('myteam\n')
+    })
 
   fancy
     .it('errors with no team', async (_, done) => {
-    try {
-      await TeamCommand.run([])
-    } catch (error) {
-      if (error instanceof Error) {
-        expect(error.message).to.contain('Missing required flag team')
-      } else {
-        throw new TypeError('Unexpected error')
-      }
+      try {
+        await TeamCommand.run([])
+      } catch (error) {
+        if (error instanceof Error) {
+          expect(error.message).to.contain('Missing required flag team')
+        } else {
+          throw new TypeError('Unexpected error')
+        }
 
-      done()
-    }
-  })
+        done()
+      }
+    })
 })
 
 describe('optional', () => {
@@ -49,54 +49,54 @@ describe('optional', () => {
   fancy
     .stdout()
     .it('--team', async ctx => {
-    await TeamCommand.run(['--team', 'myteam'])
-    expect(ctx.stdout).to.equal('myteam\n')
-  })
+      await TeamCommand.run(['--team', 'myteam'])
+      expect(ctx.stdout).to.equal('myteam\n')
+    })
 
   fancy
     .stdout()
     .it('-t', async ctx => {
-    await TeamCommand.run(['-t', 'myteam'])
-    expect(ctx.stdout).to.equal('myteam\n')
-  })
+      await TeamCommand.run(['-t', 'myteam'])
+      expect(ctx.stdout).to.equal('myteam\n')
+    })
 
   fancy
     .stdout()
     .env({HEROKU_ORGANIZATION: 'myteam'})
     .it('reads HEROKU_ORGANIZATION', async ctx => {
-    class TeamCommand extends Command {
-      static flags = {team: flags.team()}
-      async run() {
+      class TeamCommand extends Command {
+        static flags = {team: flags.team()}
+        async run() {
           const {flags} = await this.parse(this.constructor as any)
           cli.log(flags.team)
         }
-    }
+      }
 
-    await TeamCommand.run([])
-    expect(ctx.stdout).to.equal('myteam\n')
-  })
+      await TeamCommand.run([])
+      expect(ctx.stdout).to.equal('myteam\n')
+    })
 
   fancy
     .stdout()
     .env({HEROKU_TEAM: 'myteam'})
     .it('reads HEROKU_TEAM', async ctx => {
-    class TeamCommand extends Command {
-      static flags = {team: flags.team()}
-      async run() {
+      class TeamCommand extends Command {
+        static flags = {team: flags.team()}
+        async run() {
           const {flags} = await this.parse(this.constructor as any)
           cli.log(flags.team)
         }
-    }
+      }
 
-    await TeamCommand.run([])
-    expect(ctx.stdout).to.equal('myteam\n')
-  })
+      await TeamCommand.run([])
+      expect(ctx.stdout).to.equal('myteam\n')
+    })
 
   fancy
     .stdout()
     .it('does not error when team is not specified', async () => {
-    await TeamCommand.run([])
-  })
+      await TeamCommand.run([])
+    })
 })
 
 describe('with flag/env variable priorities', () => {
@@ -121,9 +121,9 @@ describe('with flag/env variable priorities', () => {
       .env({HEROKU_TEAM: 'team-env'})
       .env({HEROKU_ORGANIZATION: 'org-env'})
       .it('takes priority over an org flag and environment variables', async ctx => {
-      await TeamCommand.run(['-t', 'team-flag', '-o', 'org-flag'])
-      expect(ctx.stdout).to.equal('team-flag\n')
-    })
+        await TeamCommand.run(['-t', 'team-flag', '-o', 'org-flag'])
+        expect(ctx.stdout).to.equal('team-flag\n')
+      })
   })
 
   describe('when an org flag is used', function () {
@@ -132,9 +132,9 @@ describe('with flag/env variable priorities', () => {
       .env({HEROKU_TEAM: 'team-env'})
       .env({HEROKU_ORGANIZATION: 'org-env'})
       .it('takes priority over environment variables', async ctx => {
-      await TeamCommand.run(['-o', 'org-flag'])
-      expect(ctx.stdout).to.equal('org-flag\n')
-    })
+        await TeamCommand.run(['-o', 'org-flag'])
+        expect(ctx.stdout).to.equal('org-flag\n')
+      })
   })
 
   describe('when HEROKU_TEAM is used', function () {
@@ -143,9 +143,9 @@ describe('with flag/env variable priorities', () => {
       .env({HEROKU_TEAM: 'team-env'})
       .env({HEROKU_ORGANIZATION: 'org-env'})
       .it('takes priority over HEROKU_ORGANIZATION', async ctx => {
-      await TeamCommand.run([])
-      expect(ctx.stdout).to.equal('team-env\n')
-    })
+        await TeamCommand.run([])
+        expect(ctx.stdout).to.equal('team-env\n')
+      })
   })
 
   describe('when HEROKU_ORGANIZATION is used by itself', function () {
@@ -153,8 +153,8 @@ describe('with flag/env variable priorities', () => {
       .stdout()
       .env({HEROKU_ORGANIZATION: 'org-env'})
       .it('is is shown', async ctx => {
-      await TeamCommand.run([])
-      expect(ctx.stdout).to.equal('org-env\n')
-    })
+        await TeamCommand.run([])
+        expect(ctx.stdout).to.equal('org-env\n')
+      })
   })
 })

--- a/test/flags/team.test.ts
+++ b/test/flags/team.test.ts
@@ -15,14 +15,14 @@ describe('required', () => {
   }
 
   fancy
-  .stdout()
-  .it('has an team', async ctx => {
+    .stdout()
+    .it('has an team', async ctx => {
     await TeamCommand.run(['--team', 'myteam'])
     expect(ctx.stdout).to.equal('myteam\n')
   })
 
   fancy
-  .it('errors with no team', async (_, done) => {
+    .it('errors with no team', async (_, done) => {
     try {
       await TeamCommand.run([])
     } catch (error) {
@@ -47,26 +47,26 @@ describe('optional', () => {
   }
 
   fancy
-  .stdout()
-  .it('--team', async ctx => {
+    .stdout()
+    .it('--team', async ctx => {
     await TeamCommand.run(['--team', 'myteam'])
     expect(ctx.stdout).to.equal('myteam\n')
   })
 
   fancy
-  .stdout()
-  .it('-t', async ctx => {
+    .stdout()
+    .it('-t', async ctx => {
     await TeamCommand.run(['-t', 'myteam'])
     expect(ctx.stdout).to.equal('myteam\n')
   })
 
   fancy
-  .stdout()
-  .env({HEROKU_ORGANIZATION: 'myteam'})
-  .it('reads HEROKU_ORGANIZATION', async ctx => {
+    .stdout()
+    .env({HEROKU_ORGANIZATION: 'myteam'})
+    .it('reads HEROKU_ORGANIZATION', async ctx => {
     class TeamCommand extends Command {
-        static flags = {team: flags.team()}
-        async run() {
+      static flags = {team: flags.team()}
+      async run() {
           const {flags} = await this.parse(this.constructor as any)
           cli.log(flags.team)
         }
@@ -77,12 +77,12 @@ describe('optional', () => {
   })
 
   fancy
-  .stdout()
-  .env({HEROKU_TEAM: 'myteam'})
-  .it('reads HEROKU_TEAM', async ctx => {
+    .stdout()
+    .env({HEROKU_TEAM: 'myteam'})
+    .it('reads HEROKU_TEAM', async ctx => {
     class TeamCommand extends Command {
-        static flags = {team: flags.team()}
-        async run() {
+      static flags = {team: flags.team()}
+      async run() {
           const {flags} = await this.parse(this.constructor as any)
           cli.log(flags.team)
         }
@@ -93,8 +93,8 @@ describe('optional', () => {
   })
 
   fancy
-  .stdout()
-  .it('does not error when team is not specified', async () => {
+    .stdout()
+    .it('does not error when team is not specified', async () => {
     await TeamCommand.run([])
   })
 })
@@ -117,10 +117,10 @@ describe('with flag/env variable priorities', () => {
 
   describe('when a team flag is used', function () {
     fancy
-    .stdout()
-    .env({HEROKU_TEAM: 'team-env'})
-    .env({HEROKU_ORGANIZATION: 'org-env'})
-    .it('takes priority over an org flag and environment variables', async ctx => {
+      .stdout()
+      .env({HEROKU_TEAM: 'team-env'})
+      .env({HEROKU_ORGANIZATION: 'org-env'})
+      .it('takes priority over an org flag and environment variables', async ctx => {
       await TeamCommand.run(['-t', 'team-flag', '-o', 'org-flag'])
       expect(ctx.stdout).to.equal('team-flag\n')
     })
@@ -128,10 +128,10 @@ describe('with flag/env variable priorities', () => {
 
   describe('when an org flag is used', function () {
     fancy
-    .stdout()
-    .env({HEROKU_TEAM: 'team-env'})
-    .env({HEROKU_ORGANIZATION: 'org-env'})
-    .it('takes priority over environment variables', async ctx => {
+      .stdout()
+      .env({HEROKU_TEAM: 'team-env'})
+      .env({HEROKU_ORGANIZATION: 'org-env'})
+      .it('takes priority over environment variables', async ctx => {
       await TeamCommand.run(['-o', 'org-flag'])
       expect(ctx.stdout).to.equal('org-flag\n')
     })
@@ -139,10 +139,10 @@ describe('with flag/env variable priorities', () => {
 
   describe('when HEROKU_TEAM is used', function () {
     fancy
-    .stdout()
-    .env({HEROKU_TEAM: 'team-env'})
-    .env({HEROKU_ORGANIZATION: 'org-env'})
-    .it('takes priority over HEROKU_ORGANIZATION', async ctx => {
+      .stdout()
+      .env({HEROKU_TEAM: 'team-env'})
+      .env({HEROKU_ORGANIZATION: 'org-env'})
+      .it('takes priority over HEROKU_ORGANIZATION', async ctx => {
       await TeamCommand.run([])
       expect(ctx.stdout).to.equal('team-env\n')
     })
@@ -150,9 +150,9 @@ describe('with flag/env variable priorities', () => {
 
   describe('when HEROKU_ORGANIZATION is used by itself', function () {
     fancy
-    .stdout()
-    .env({HEROKU_ORGANIZATION: 'org-env'})
-    .it('is is shown', async ctx => {
+      .stdout()
+      .env({HEROKU_ORGANIZATION: 'org-env'})
+      .it('is is shown', async ctx => {
       await TeamCommand.run([])
       expect(ctx.stdout).to.equal('org-env\n')
     })

--- a/test/flags/team.test.ts
+++ b/test/flags/team.test.ts
@@ -1,14 +1,15 @@
-import {Command} from '@oclif/command'
-import {cli} from 'cli-ux'
+import {CliUx, Command} from '@oclif/core'
 import {expect, fancy} from 'fancy-test'
 
 import * as flags from '../../src/flags'
+
+const cli = CliUx.ux
 
 describe('required', () => {
   class TeamCommand extends Command {
     static flags = {team: flags.team({required: true})}
     async run() {
-      const {flags} = this.parse(this.constructor as any)
+      const {flags} = await this.parse(this.constructor as any)
       cli.log(flags.team)
     }
   }
@@ -25,7 +26,12 @@ describe('required', () => {
     try {
       await TeamCommand.run([])
     } catch (error) {
-      expect(error.message).to.contain('Missing required flag:\n -t, --team')
+      if (error instanceof Error) {
+        expect(error.message).to.contain('Missing required flag team')
+      } else {
+        throw new TypeError('Unhandled error state')
+      }
+
       done()
     }
   })
@@ -35,7 +41,7 @@ describe('optional', () => {
   class TeamCommand extends Command {
     static flags = {team: flags.team()}
     async run() {
-      const {flags} = this.parse(this.constructor as any)
+      const {flags} = await this.parse(this.constructor as any)
       cli.log(flags.team)
     }
   }
@@ -61,7 +67,7 @@ describe('optional', () => {
     class TeamCommand extends Command {
         static flags = {team: flags.team()}
         async run() {
-          const {flags} = this.parse(this.constructor as any)
+          const {flags} = await this.parse(this.constructor as any)
           cli.log(flags.team)
         }
     }
@@ -77,7 +83,7 @@ describe('optional', () => {
     class TeamCommand extends Command {
         static flags = {team: flags.team()}
         async run() {
-          const {flags} = this.parse(this.constructor as any)
+          const {flags} = await this.parse(this.constructor as any)
           cli.log(flags.team)
         }
     }
@@ -104,7 +110,7 @@ describe('with flag/env variable priorities', () => {
     }
 
     async run() {
-      const {flags} = this.parse(this.constructor as any)
+      const {flags} = await this.parse(this.constructor as any)
       cli.log(flags.team)
     }
   }

--- a/test/flags/team.test.ts
+++ b/test/flags/team.test.ts
@@ -29,7 +29,7 @@ describe('required', () => {
       if (error instanceof Error) {
         expect(error.message).to.contain('Missing required flag team')
       } else {
-        throw new TypeError('Unhandled error state')
+        throw new TypeError('Unexpected error')
       }
 
       done()

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -1,5 +1,5 @@
+import childProcess from 'child_process'
 import {expect, fancy} from 'fancy-test'
-import childProcess from 'node:child_process'
 
 import {Git} from '../src/git'
 
@@ -19,14 +19,14 @@ heroku\thttps://git.heroku.com/myapp.git  (pull)
 
   fancy
     .stub(childProcess, 'execSync', () => {
-    const err: any = new Error('some other message')
-    err.code = 'ENOTNOENT'
-    throw err
-  })
+      const err: any = new Error('some other message')
+      err.code = 'ENOTNOENT'
+      throw err
+    })
     .it('rethrows other git error', () => {
-    const git = new Git()
-    expect(() => {
-      git.exec('version')
-    }).to.throw('some other message')
-  })
+      const git = new Git()
+      expect(() => {
+        git.exec('version')
+      }).to.throw('some other message')
+    })
 })

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -1,5 +1,5 @@
-import childProcess from 'node:child_process'
 import {expect, fancy} from 'fancy-test'
+import childProcess from 'node:child_process'
 
 import {Git} from '../src/git'
 
@@ -18,12 +18,12 @@ heroku\thttps://git.heroku.com/myapp.git  (pull)
   })
 
   fancy
-  .stub(childProcess, 'execSync', () => {
+    .stub(childProcess, 'execSync', () => {
     const err: any = new Error('some other message')
     err.code = 'ENOTNOENT'
     throw err
   })
-  .it('rethrows other git error', () => {
+    .it('rethrows other git error', () => {
     const git = new Git()
     expect(() => {
       git.exec('version')

--- a/test/login.test.ts
+++ b/test/login.test.ts
@@ -1,7 +1,7 @@
 import {Config} from '@oclif/core'
 import base, {expect} from 'fancy-test'
 import nock from 'nock'
-import {resolve} from 'node:path'
+import {resolve} from 'path'
 
 import {Command as CommandBase} from '../src/command'
 
@@ -23,67 +23,67 @@ const test = base
 describe('login with interactive', () => {
   test
     .it('throws a custom error message body for device_trust_required error', async ctx => {
-    const cmd = new Command([], ctx.config)
-    api
+      const cmd = new Command([], ctx.config)
+      api
       .post('/oauth/authorizations')
       .reply(401, {id: 'device_trust_required', message: 'original error message'})
 
-    await cmd.heroku.login({method: 'interactive'})
+      await cmd.heroku.login({method: 'interactive'})
       .catch(error => {
-      expect(error.message).to.contain('The interactive flag requires Two-Factor Authentication')
-      expect(error.message).to.contain('Error ID: device_trust_required')
+        expect(error.message).to.contain('The interactive flag requires Two-Factor Authentication')
+        expect(error.message).to.contain('Error ID: device_trust_required')
+      })
     })
-  })
 
   test
     .it('sends any other error message body through', async ctx => {
-    const cmd = new Command([], ctx.config)
-    api
+      const cmd = new Command([], ctx.config)
+      api
       .post('/oauth/authorizations')
       .reply(401, {id: 'unauthorized', message: 'original error message'})
 
-    await cmd.heroku.login({method: 'interactive'})
+      await cmd.heroku.login({method: 'interactive'})
       .catch(error => {
-      expect(error.message).to.contain('original error message')
-      expect(error.message).to.contain('Error ID: unauthorized')
+        expect(error.message).to.contain('original error message')
+        expect(error.message).to.contain('Error ID: unauthorized')
+      })
     })
-  })
 
   test
     .it('defaults to 30 days login', async ctx => {
-    const cmd = new Command([], ctx.config)
-    api
+      const cmd = new Command([], ctx.config)
+      api
       .post('/oauth/authorizations',
       {scope: ['global'], description: /^Heroku CLI login from .*/, expires_in: 60 * 60 * 24 * 30})
       .reply(401, {id: 'unauthorized', message: 'not authorized'})
 
-    await cmd.heroku.login({method: 'interactive'})
+      await cmd.heroku.login({method: 'interactive'})
       .catch(error => {
-      expect(error.message).to.contain('Error ID: unauthorized')
+        expect(error.message).to.contain('Error ID: unauthorized')
+      })
     })
-  })
 
   test
     .it('allows shorter logins', async ctx => {
-    const cmd = new Command([], ctx.config)
-    api
+      const cmd = new Command([], ctx.config)
+      api
       .post('/oauth/authorizations',
       {scope: ['global'], description: /^Heroku CLI login from .*/, expires_in: 12_345})
       .reply(401, {id: 'unauthorized', message: 'not authorized'})
 
-    await cmd.heroku.login({method: 'interactive', expiresIn: 12_345})
+      await cmd.heroku.login({method: 'interactive', expiresIn: 12_345})
       .catch(error => {
-      expect(error.message).to.contain('Error ID: unauthorized')
+        expect(error.message).to.contain('Error ID: unauthorized')
+      })
     })
-  })
 
   test
     .it('does not allow logins longer than 30 days', async ctx => {
-    const cmd = new Command([], ctx.config)
+      const cmd = new Command([], ctx.config)
 
-    await cmd.heroku.login({method: 'interactive', expiresIn: 60 * 60 * 24 * 31})
+      await cmd.heroku.login({method: 'interactive', expiresIn: 60 * 60 * 24 * 31})
       .catch(error => {
-      expect(error.message).to.contain('Cannot set an expiration longer than thirty days')
+        expect(error.message).to.contain('Cannot set an expiration longer than thirty days')
+      })
     })
-  })
 })

--- a/test/login.test.ts
+++ b/test/login.test.ts
@@ -22,67 +22,67 @@ const test = base
 
 describe('login with interactive', () => {
   test
-  .it('throws a custom error message body for device_trust_required error', async ctx => {
+    .it('throws a custom error message body for device_trust_required error', async ctx => {
     const cmd = new Command([], ctx.config)
     api
-    .post('/oauth/authorizations')
-    .reply(401, {id: 'device_trust_required', message: 'original error message'})
+      .post('/oauth/authorizations')
+      .reply(401, {id: 'device_trust_required', message: 'original error message'})
 
     await cmd.heroku.login({method: 'interactive'})
-    .catch(error => {
+      .catch(error => {
       expect(error.message).to.contain('The interactive flag requires Two-Factor Authentication')
       expect(error.message).to.contain('Error ID: device_trust_required')
     })
   })
 
   test
-  .it('sends any other error message body through', async ctx => {
+    .it('sends any other error message body through', async ctx => {
     const cmd = new Command([], ctx.config)
     api
-    .post('/oauth/authorizations')
-    .reply(401, {id: 'unauthorized', message: 'original error message'})
+      .post('/oauth/authorizations')
+      .reply(401, {id: 'unauthorized', message: 'original error message'})
 
     await cmd.heroku.login({method: 'interactive'})
-    .catch(error => {
+      .catch(error => {
       expect(error.message).to.contain('original error message')
       expect(error.message).to.contain('Error ID: unauthorized')
     })
   })
 
   test
-  .it('defaults to 30 days login', async ctx => {
+    .it('defaults to 30 days login', async ctx => {
     const cmd = new Command([], ctx.config)
     api
-    .post('/oauth/authorizations',
+      .post('/oauth/authorizations',
       {scope: ['global'], description: /^Heroku CLI login from .*/, expires_in: 60 * 60 * 24 * 30})
-    .reply(401, {id: 'unauthorized', message: 'not authorized'})
+      .reply(401, {id: 'unauthorized', message: 'not authorized'})
 
     await cmd.heroku.login({method: 'interactive'})
-    .catch(error => {
+      .catch(error => {
       expect(error.message).to.contain('Error ID: unauthorized')
     })
   })
 
   test
-  .it('allows shorter logins', async ctx => {
+    .it('allows shorter logins', async ctx => {
     const cmd = new Command([], ctx.config)
     api
-    .post('/oauth/authorizations',
+      .post('/oauth/authorizations',
       {scope: ['global'], description: /^Heroku CLI login from .*/, expires_in: 12_345})
-    .reply(401, {id: 'unauthorized', message: 'not authorized'})
+      .reply(401, {id: 'unauthorized', message: 'not authorized'})
 
     await cmd.heroku.login({method: 'interactive', expiresIn: 12_345})
-    .catch(error => {
+      .catch(error => {
       expect(error.message).to.contain('Error ID: unauthorized')
     })
   })
 
   test
-  .it('does not allow logins longer than 30 days', async ctx => {
+    .it('does not allow logins longer than 30 days', async ctx => {
     const cmd = new Command([], ctx.config)
 
     await cmd.heroku.login({method: 'interactive', expiresIn: 60 * 60 * 24 * 31})
-    .catch(error => {
+      .catch(error => {
       expect(error.message).to.contain('Cannot set an expiration longer than thirty days')
     })
   })

--- a/test/login.test.ts
+++ b/test/login.test.ts
@@ -25,56 +25,56 @@ describe('login with interactive', () => {
     .it('throws a custom error message body for device_trust_required error', async ctx => {
       const cmd = new Command([], ctx.config)
       api
-      .post('/oauth/authorizations')
-      .reply(401, {id: 'device_trust_required', message: 'original error message'})
+        .post('/oauth/authorizations')
+        .reply(401, {id: 'device_trust_required', message: 'original error message'})
 
       await cmd.heroku.login({method: 'interactive'})
-      .catch(error => {
-        expect(error.message).to.contain('The interactive flag requires Two-Factor Authentication')
-        expect(error.message).to.contain('Error ID: device_trust_required')
-      })
+        .catch(error => {
+          expect(error.message).to.contain('The interactive flag requires Two-Factor Authentication')
+          expect(error.message).to.contain('Error ID: device_trust_required')
+        })
     })
 
   test
     .it('sends any other error message body through', async ctx => {
       const cmd = new Command([], ctx.config)
       api
-      .post('/oauth/authorizations')
-      .reply(401, {id: 'unauthorized', message: 'original error message'})
+        .post('/oauth/authorizations')
+        .reply(401, {id: 'unauthorized', message: 'original error message'})
 
       await cmd.heroku.login({method: 'interactive'})
-      .catch(error => {
-        expect(error.message).to.contain('original error message')
-        expect(error.message).to.contain('Error ID: unauthorized')
-      })
+        .catch(error => {
+          expect(error.message).to.contain('original error message')
+          expect(error.message).to.contain('Error ID: unauthorized')
+        })
     })
 
   test
     .it('defaults to 30 days login', async ctx => {
       const cmd = new Command([], ctx.config)
       api
-      .post('/oauth/authorizations',
+        .post('/oauth/authorizations',
       {scope: ['global'], description: /^Heroku CLI login from .*/, expires_in: 60 * 60 * 24 * 30})
-      .reply(401, {id: 'unauthorized', message: 'not authorized'})
+        .reply(401, {id: 'unauthorized', message: 'not authorized'})
 
       await cmd.heroku.login({method: 'interactive'})
-      .catch(error => {
-        expect(error.message).to.contain('Error ID: unauthorized')
-      })
+        .catch(error => {
+          expect(error.message).to.contain('Error ID: unauthorized')
+        })
     })
 
   test
     .it('allows shorter logins', async ctx => {
       const cmd = new Command([], ctx.config)
       api
-      .post('/oauth/authorizations',
+        .post('/oauth/authorizations',
       {scope: ['global'], description: /^Heroku CLI login from .*/, expires_in: 12_345})
-      .reply(401, {id: 'unauthorized', message: 'not authorized'})
+        .reply(401, {id: 'unauthorized', message: 'not authorized'})
 
       await cmd.heroku.login({method: 'interactive', expiresIn: 12_345})
-      .catch(error => {
-        expect(error.message).to.contain('Error ID: unauthorized')
-      })
+        .catch(error => {
+          expect(error.message).to.contain('Error ID: unauthorized')
+        })
     })
 
   test
@@ -82,8 +82,8 @@ describe('login with interactive', () => {
       const cmd = new Command([], ctx.config)
 
       await cmd.heroku.login({method: 'interactive', expiresIn: 60 * 60 * 24 * 31})
-      .catch(error => {
-        expect(error.message).to.contain('Cannot set an expiration longer than thirty days')
-      })
+        .catch(error => {
+          expect(error.message).to.contain('Cannot set an expiration longer than thirty days')
+        })
     })
 })

--- a/test/login.test.ts
+++ b/test/login.test.ts
@@ -1,6 +1,7 @@
-import * as Config from '@oclif/config'
+import {Config} from '@oclif/core'
 import base, {expect} from 'fancy-test'
 import nock from 'nock'
+import {resolve} from 'node:path'
 
 import {Command as CommandBase} from '../src/command'
 
@@ -17,7 +18,7 @@ beforeEach(() => {
 })
 
 const test = base
-.add('config', () => Config.load())
+.add('config', new Config({root: resolve(__dirname, '../package.json')}))
 
 describe('login with interactive', () => {
   test

--- a/test/mutex.test.ts
+++ b/test/mutex.test.ts
@@ -57,42 +57,42 @@ describe('mutex', () => {
       }),
     ])
       .then(() => {
-      throw new Error('x')
-    })
+        throw new Error('x')
+      })
       .catch(error => {
-      expect(error.message).to.deep.equal('bar')
-      expect(output).to.deep.equal(['foo', 'bar', 'biz'])
-    })
+        expect(error.message).to.deep.equal('bar')
+        expect(output).to.deep.equal(['foo', 'bar', 'biz'])
+      })
   })
 
   it('should run promises after draining the queue', done => {
     const mutex = new Mutex()
     mutex
       .synchronize(() => {
-      return new Promise(resolve => {
-        output.push('foo')
-        resolve('foo')
+        return new Promise(resolve => {
+          output.push('foo')
+          resolve('foo')
+        })
       })
-    })
       .then(results => {
-      setImmediate(() => {
-        expect('foo').to.deep.equal(results)
-        expect(output).to.deep.equal(['foo'])
+        setImmediate(() => {
+          expect('foo').to.deep.equal(results)
+          expect(output).to.deep.equal(['foo'])
 
-        return mutex
+          return mutex
           .synchronize(() => {
-          return new Promise(resolve => {
-            output.push('bar')
-            resolve('bar')
+            return new Promise(resolve => {
+              output.push('bar')
+              resolve('bar')
+            })
+          })
+          .then(results => {
+            expect('bar').to.deep.equal(results)
+            expect(output).to.deep.equal(['foo', 'bar'])
+            done()
           })
         })
-          .then(results => {
-          expect('bar').to.deep.equal(results)
-          expect(output).to.deep.equal(['foo', 'bar'])
-          done()
-        })
       })
-    })
       .catch(done)
   })
 })

--- a/test/mutex.test.ts
+++ b/test/mutex.test.ts
@@ -56,10 +56,10 @@ describe('mutex', () => {
         })
       }),
     ])
-    .then(() => {
+      .then(() => {
       throw new Error('x')
     })
-    .catch(error => {
+      .catch(error => {
       expect(error.message).to.deep.equal('bar')
       expect(output).to.deep.equal(['foo', 'bar', 'biz'])
     })
@@ -68,31 +68,31 @@ describe('mutex', () => {
   it('should run promises after draining the queue', done => {
     const mutex = new Mutex()
     mutex
-    .synchronize(() => {
+      .synchronize(() => {
       return new Promise(resolve => {
         output.push('foo')
         resolve('foo')
       })
     })
-    .then(results => {
+      .then(results => {
       setImmediate(() => {
         expect('foo').to.deep.equal(results)
         expect(output).to.deep.equal(['foo'])
 
         return mutex
-        .synchronize(() => {
+          .synchronize(() => {
           return new Promise(resolve => {
             output.push('bar')
             resolve('bar')
           })
         })
-        .then(results => {
+          .then(results => {
           expect('bar').to.deep.equal(results)
           expect(output).to.deep.equal(['foo', 'bar'])
           done()
         })
       })
     })
-    .catch(done)
+      .catch(done)
   })
 })

--- a/test/mutex.test.ts
+++ b/test/mutex.test.ts
@@ -80,17 +80,17 @@ describe('mutex', () => {
           expect(output).to.deep.equal(['foo'])
 
           return mutex
-          .synchronize(() => {
-            return new Promise(resolve => {
-              output.push('bar')
-              resolve('bar')
+            .synchronize(() => {
+              return new Promise(resolve => {
+                output.push('bar')
+                resolve('bar')
+              })
             })
-          })
-          .then(results => {
-            expect('bar').to.deep.equal(results)
-            expect(output).to.deep.equal(['foo', 'bar'])
-            done()
-          })
+            .then(results => {
+              expect('bar').to.deep.equal(results)
+              expect(output).to.deep.equal(['foo', 'bar'])
+              done()
+            })
         })
       })
       .catch(done)

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@oclif/tslint"
+}

--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,3 @@
 {
-  "extends": "@oclif/tslint",
-  "rules": {
-    "ter-indent": [ true, 2, { "SwitchCase": 1 }]
-  }
+  "extends": "@oclif/tslint"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,239 +2,24 @@
 # yarn lockfile v1
 
 
-"@ampproject/remapping@^2.1.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.0.tgz#56c133824780de3174aed5ab6834f3026790154d"
-  integrity sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==
+"@fimbul/bifrost@^0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@fimbul/bifrost/-/bifrost-0.21.0.tgz#d0fafa25938fda475657a6a1e407a21bbe02c74e"
+  integrity sha512-ou8VU+nTmOW1jeg+FT+sn+an/M0Xb9G16RucrfhjXGWv1Q97kCoM5CG9Qj7GYOSdu7km72k7nY83Eyr53Bkakg==
   dependencies:
-    "@jridgewell/gen-mapping" "^0.1.0"
-    "@jridgewell/trace-mapping" "^0.3.9"
+    "@fimbul/ymir" "^0.21.0"
+    get-caller-file "^2.0.0"
+    tslib "^1.8.1"
+    tsutils "^3.5.0"
 
-"@babel/code-frame@7.12.11":
-  version "7.12.11"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"
-  integrity sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==
+"@fimbul/ymir@^0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@fimbul/ymir/-/ymir-0.21.0.tgz#8525726787aceeafd4e199472c0d795160b5d4a1"
+  integrity sha512-T/y7WqPsm4n3zhT08EpB5sfdm2Kvw3gurAxr2Lr5dQeLi8ZsMlNT/Jby+ZmuuAAd1PnXYzKp+2SXgIkQIIMCUg==
   dependencies:
-    "@babel/highlight" "^7.10.4"
-
-"@babel/code-frame@^7.0.0":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.8.3.tgz#33e25903d7481181534e12ec0a25f16b6fcf419e"
-  integrity sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==
-  dependencies:
-    "@babel/highlight" "^7.8.3"
-
-"@babel/code-frame@^7.18.6":
-  version "7.18.6"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.18.6.tgz#3b25d38c89600baa2dcc219edfa88a74eb2c427a"
-  integrity sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==
-  dependencies:
-    "@babel/highlight" "^7.18.6"
-
-"@babel/compat-data@^7.20.0":
-  version "7.20.1"
-  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.20.1.tgz#f2e6ef7790d8c8dbf03d379502dcc246dcce0b30"
-  integrity sha512-EWZ4mE2diW3QALKvDMiXnbZpRvlj+nayZ112nK93SnhqOtpdsbVD4W+2tEoT3YNBAG9RBR0ISY758ZkOgsn6pQ==
-
-"@babel/core@^7.12.16":
-  version "7.19.6"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.19.6.tgz#7122ae4f5c5a37c0946c066149abd8e75f81540f"
-  integrity sha512-D2Ue4KHpc6Ys2+AxpIx1BZ8+UegLLLE2p3KJEuJRKmokHOtl49jQ5ny1773KsGLZs8MQvBidAF6yWUJxRqtKtg==
-  dependencies:
-    "@ampproject/remapping" "^2.1.0"
-    "@babel/code-frame" "^7.18.6"
-    "@babel/generator" "^7.19.6"
-    "@babel/helper-compilation-targets" "^7.19.3"
-    "@babel/helper-module-transforms" "^7.19.6"
-    "@babel/helpers" "^7.19.4"
-    "@babel/parser" "^7.19.6"
-    "@babel/template" "^7.18.10"
-    "@babel/traverse" "^7.19.6"
-    "@babel/types" "^7.19.4"
-    convert-source-map "^1.7.0"
-    debug "^4.1.0"
-    gensync "^1.0.0-beta.2"
-    json5 "^2.2.1"
-    semver "^6.3.0"
-
-"@babel/eslint-parser@^7.12.16":
-  version "7.19.1"
-  resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.19.1.tgz#4f68f6b0825489e00a24b41b6a1ae35414ecd2f4"
-  integrity sha512-AqNf2QWt1rtu2/1rLswy6CDP7H9Oh3mMhk177Y67Rg8d7RD9WfOLLv8CGn6tisFvS2htm86yIe1yLF6I1UDaGQ==
-  dependencies:
-    "@nicolo-ribaudo/eslint-scope-5-internals" "5.1.1-v1"
-    eslint-visitor-keys "^2.1.0"
-    semver "^6.3.0"
-
-"@babel/generator@^7.19.6", "@babel/generator@^7.20.1":
-  version "7.20.1"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.20.1.tgz#ef32ecd426222624cbd94871a7024639cf61a9fa"
-  integrity sha512-u1dMdBUmA7Z0rBB97xh8pIhviK7oItYOkjbsCxTWMknyvbQRBwX7/gn4JXurRdirWMFh+ZtYARqkA6ydogVZpg==
-  dependencies:
-    "@babel/types" "^7.20.0"
-    "@jridgewell/gen-mapping" "^0.3.2"
-    jsesc "^2.5.1"
-
-"@babel/helper-compilation-targets@^7.19.3":
-  version "7.20.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.0.tgz#6bf5374d424e1b3922822f1d9bdaa43b1a139d0a"
-  integrity sha512-0jp//vDGp9e8hZzBc6N/KwA5ZK3Wsm/pfm4CrY7vzegkVxc65SgSn6wYOnwHe9Js9HRQ1YTCKLGPzDtaS3RoLQ==
-  dependencies:
-    "@babel/compat-data" "^7.20.0"
-    "@babel/helper-validator-option" "^7.18.6"
-    browserslist "^4.21.3"
-    semver "^6.3.0"
-
-"@babel/helper-environment-visitor@^7.18.9":
-  version "7.18.9"
-  resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz#0c0cee9b35d2ca190478756865bb3528422f51be"
-  integrity sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==
-
-"@babel/helper-function-name@^7.19.0":
-  version "7.19.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz#941574ed5390682e872e52d3f38ce9d1bef4648c"
-  integrity sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==
-  dependencies:
-    "@babel/template" "^7.18.10"
-    "@babel/types" "^7.19.0"
-
-"@babel/helper-hoist-variables@^7.18.6":
-  version "7.18.6"
-  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz#d4d2c8fb4baeaa5c68b99cc8245c56554f926678"
-  integrity sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==
-  dependencies:
-    "@babel/types" "^7.18.6"
-
-"@babel/helper-module-imports@^7.18.6":
-  version "7.18.6"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz#1e3ebdbbd08aad1437b428c50204db13c5a3ca6e"
-  integrity sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==
-  dependencies:
-    "@babel/types" "^7.18.6"
-
-"@babel/helper-module-transforms@^7.19.6":
-  version "7.19.6"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.19.6.tgz#6c52cc3ac63b70952d33ee987cbee1c9368b533f"
-  integrity sha512-fCmcfQo/KYr/VXXDIyd3CBGZ6AFhPFy1TfSEJ+PilGVlQT6jcbqtHAM4C1EciRqMza7/TpOUZliuSH+U6HAhJw==
-  dependencies:
-    "@babel/helper-environment-visitor" "^7.18.9"
-    "@babel/helper-module-imports" "^7.18.6"
-    "@babel/helper-simple-access" "^7.19.4"
-    "@babel/helper-split-export-declaration" "^7.18.6"
-    "@babel/helper-validator-identifier" "^7.19.1"
-    "@babel/template" "^7.18.10"
-    "@babel/traverse" "^7.19.6"
-    "@babel/types" "^7.19.4"
-
-"@babel/helper-simple-access@^7.19.4":
-  version "7.19.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.19.4.tgz#be553f4951ac6352df2567f7daa19a0ee15668e7"
-  integrity sha512-f9Xq6WqBFqaDfbCzn2w85hwklswz5qsKlh7f08w4Y9yhJHpnNC0QemtSkK5YyOY8kPGvyiwdzZksGUhnGdaUIg==
-  dependencies:
-    "@babel/types" "^7.19.4"
-
-"@babel/helper-split-export-declaration@^7.18.6":
-  version "7.18.6"
-  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz#7367949bc75b20c6d5a5d4a97bba2824ae8ef075"
-  integrity sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==
-  dependencies:
-    "@babel/types" "^7.18.6"
-
-"@babel/helper-string-parser@^7.19.4":
-  version "7.19.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz#38d3acb654b4701a9b77fb0615a96f775c3a9e63"
-  integrity sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==
-
-"@babel/helper-validator-identifier@^7.14.9", "@babel/helper-validator-identifier@^7.18.6", "@babel/helper-validator-identifier@^7.19.1":
-  version "7.19.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz#7eea834cf32901ffdc1a7ee555e2f9c27e249ca2"
-  integrity sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==
-
-"@babel/helper-validator-option@^7.18.6":
-  version "7.18.6"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz#bf0d2b5a509b1f336099e4ff36e1a63aa5db4db8"
-  integrity sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==
-
-"@babel/helpers@^7.19.4":
-  version "7.20.1"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.20.1.tgz#2ab7a0fcb0a03b5bf76629196ed63c2d7311f4c9"
-  integrity sha512-J77mUVaDTUJFZ5BpP6mMn6OIl3rEWymk2ZxDBQJUG3P+PbmyMcF3bYWvz0ma69Af1oobDqT/iAsvzhB58xhQUg==
-  dependencies:
-    "@babel/template" "^7.18.10"
-    "@babel/traverse" "^7.20.1"
-    "@babel/types" "^7.20.0"
-
-"@babel/highlight@^7.10.4", "@babel/highlight@^7.18.6":
-  version "7.18.6"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.18.6.tgz#81158601e93e2563795adcbfbdf5d64be3f2ecdf"
-  integrity sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.18.6"
-    chalk "^2.0.0"
-    js-tokens "^4.0.0"
-
-"@babel/highlight@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.8.3.tgz#28f173d04223eaaa59bc1d439a3836e6d1265797"
-  integrity sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==
-  dependencies:
-    chalk "^2.0.0"
-    esutils "^2.0.2"
-    js-tokens "^4.0.0"
-
-"@babel/parser@^7.18.10", "@babel/parser@^7.19.6", "@babel/parser@^7.20.1":
-  version "7.20.1"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.20.1.tgz#3e045a92f7b4623cafc2425eddcb8cf2e54f9cc5"
-  integrity sha512-hp0AYxaZJhxULfM1zyp7Wgr+pSUKBcP3M+PHnSzWGdXOzg/kHWIgiUWARvubhUKGOEw3xqY4x+lyZ9ytBVcELw==
-
-"@babel/template@^7.18.10":
-  version "7.18.10"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.18.10.tgz#6f9134835970d1dbf0835c0d100c9f38de0c5e71"
-  integrity sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==
-  dependencies:
-    "@babel/code-frame" "^7.18.6"
-    "@babel/parser" "^7.18.10"
-    "@babel/types" "^7.18.10"
-
-"@babel/traverse@^7.19.6", "@babel/traverse@^7.20.1":
-  version "7.20.1"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.20.1.tgz#9b15ccbf882f6d107eeeecf263fbcdd208777ec8"
-  integrity sha512-d3tN8fkVJwFLkHkBN479SOsw4DMZnz8cdbL/gvuDuzy3TS6Nfw80HuQqhw1pITbIruHyh7d1fMA47kWzmcUEGA==
-  dependencies:
-    "@babel/code-frame" "^7.18.6"
-    "@babel/generator" "^7.20.1"
-    "@babel/helper-environment-visitor" "^7.18.9"
-    "@babel/helper-function-name" "^7.19.0"
-    "@babel/helper-hoist-variables" "^7.18.6"
-    "@babel/helper-split-export-declaration" "^7.18.6"
-    "@babel/parser" "^7.20.1"
-    "@babel/types" "^7.20.0"
-    debug "^4.1.0"
-    globals "^11.1.0"
-
-"@babel/types@^7.18.10", "@babel/types@^7.18.6", "@babel/types@^7.19.0", "@babel/types@^7.19.4", "@babel/types@^7.20.0":
-  version "7.20.0"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.20.0.tgz#52c94cf8a7e24e89d2a194c25c35b17a64871479"
-  integrity sha512-Jlgt3H0TajCW164wkTOTzHkZb075tMQMULzrLUoUeKmO7eFL96GgDxf7/Axhc5CAuKE3KFyVW1p6ysKsi2oXAg==
-  dependencies:
-    "@babel/helper-string-parser" "^7.19.4"
-    "@babel/helper-validator-identifier" "^7.19.1"
-    to-fast-properties "^2.0.0"
-
-"@eslint/eslintrc@^0.4.3":
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.3.tgz#9e42981ef035beb3dd49add17acb96e8ff6f394c"
-  integrity sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==
-  dependencies:
-    ajv "^6.12.4"
-    debug "^4.1.1"
-    espree "^7.3.0"
-    globals "^13.9.0"
-    ignore "^4.0.6"
-    import-fresh "^3.2.1"
-    js-yaml "^3.13.1"
-    minimatch "^3.0.4"
-    strip-json-comments "^3.1.1"
+    inversify "^5.0.0"
+    reflect-metadata "^0.1.12"
+    tslib "^1.8.1"
 
 "@heroku-cli/color@^1.1.14":
   version "1.1.14"
@@ -259,67 +44,6 @@
   dependencies:
     tslint "^5.8.0"
     tslint-config-prettier "*"
-
-"@humanwhocodes/config-array@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.5.0.tgz#1407967d4c6eecd7388f83acf1eaf4d0c6e58ef9"
-  integrity sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==
-  dependencies:
-    "@humanwhocodes/object-schema" "^1.2.0"
-    debug "^4.1.1"
-    minimatch "^3.0.4"
-
-"@humanwhocodes/object-schema@^1.2.0":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
-  integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
-
-"@jridgewell/gen-mapping@^0.1.0":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz#e5d2e450306a9491e3bd77e323e38d7aff315996"
-  integrity sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==
-  dependencies:
-    "@jridgewell/set-array" "^1.0.0"
-    "@jridgewell/sourcemap-codec" "^1.4.10"
-
-"@jridgewell/gen-mapping@^0.3.2":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz#c1aedc61e853f2bb9f5dfe6d4442d3b565b253b9"
-  integrity sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==
-  dependencies:
-    "@jridgewell/set-array" "^1.0.1"
-    "@jridgewell/sourcemap-codec" "^1.4.10"
-    "@jridgewell/trace-mapping" "^0.3.9"
-
-"@jridgewell/resolve-uri@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz#2203b118c157721addfe69d47b70465463066d78"
-  integrity sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==
-
-"@jridgewell/set-array@^1.0.0", "@jridgewell/set-array@^1.0.1":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.2.tgz#7c6cf998d6d20b914c0a55a91ae928ff25965e72"
-  integrity sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==
-
-"@jridgewell/sourcemap-codec@1.4.14", "@jridgewell/sourcemap-codec@^1.4.10":
-  version "1.4.14"
-  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
-  integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
-
-"@jridgewell/trace-mapping@^0.3.9":
-  version "0.3.17"
-  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz#793041277af9073b0951a7fe0f0d8c4c98c36985"
-  integrity sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==
-  dependencies:
-    "@jridgewell/resolve-uri" "3.1.0"
-    "@jridgewell/sourcemap-codec" "1.4.14"
-
-"@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1":
-  version "5.1.1-v1"
-  resolved "https://registry.yarnpkg.com/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz#dbf733a965ca47b1973177dc0bb6c889edcfb129"
-  integrity sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==
-  dependencies:
-    eslint-scope "5.1.1"
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -391,6 +115,14 @@
   resolved "https://registry.yarnpkg.com/@oclif/screen/-/screen-3.0.3.tgz#e679ad10535e31d333f809f7a71335cc9aef1e55"
   integrity sha512-KX8gMYA9ujBPOd1HFsV9e0iEx7Uoj8AG/3YsW4TtWQTg4lJvr82qNm7o/cFQfYRIt+jw7Ew/4oL4A22zOT+IRA==
 
+"@oclif/tslint@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@oclif/tslint/-/tslint-3.1.1.tgz#e055cdf158630862fd44546f6b8fb1266c9778e7"
+  integrity sha512-B1ZWbgzwxDhNZLzVnn+JjyFf9u+J9wNwsz/ZX9YvA9edRYcdiJz9JikCttGPi35V0NU0TUV4UqTqo/q/wQ06jQ==
+  dependencies:
+    tslint-eslint-rules "^5.4.0"
+    tslint-xo "^0.9.0"
+
 "@sinonjs/commons@^1", "@sinonjs/commons@^1.7.0":
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.7.0.tgz#f90ffc52a2e519f018b13b6c4da03cbff36ebed6"
@@ -458,11 +190,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/json-schema@^7.0.7":
-  version "7.0.11"
-  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
-  integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
-
 "@types/lodash@*":
   version "4.14.149"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.149.tgz#1342d63d948c6062838fbf961012f74d4e638440"
@@ -489,11 +216,6 @@
   version "18.11.9"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.9.tgz#02d013de7058cea16d36168ef2fc653464cfbad4"
   integrity sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==
-
-"@types/normalize-package-data@^2.4.0":
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"
-  integrity sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==
 
 "@types/proxyquire@^1.3.28":
   version "1.3.28"
@@ -527,115 +249,10 @@
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.0.tgz#215c231dff736d5ba92410e6d602050cce7e273f"
   integrity sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==
 
-"@typescript-eslint/eslint-plugin@^4.31.2":
-  version "4.33.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz#c24dc7c8069c7706bc40d99f6fa87edcb2005276"
-  integrity sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==
-  dependencies:
-    "@typescript-eslint/experimental-utils" "4.33.0"
-    "@typescript-eslint/scope-manager" "4.33.0"
-    debug "^4.3.1"
-    functional-red-black-tree "^1.0.1"
-    ignore "^5.1.8"
-    regexpp "^3.1.0"
-    semver "^7.3.5"
-    tsutils "^3.21.0"
-
-"@typescript-eslint/experimental-utils@4.33.0":
-  version "4.33.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz#6f2a786a4209fa2222989e9380b5331b2810f7fd"
-  integrity sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==
-  dependencies:
-    "@types/json-schema" "^7.0.7"
-    "@typescript-eslint/scope-manager" "4.33.0"
-    "@typescript-eslint/types" "4.33.0"
-    "@typescript-eslint/typescript-estree" "4.33.0"
-    eslint-scope "^5.1.1"
-    eslint-utils "^3.0.0"
-
-"@typescript-eslint/parser@^4.31.2":
-  version "4.33.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.33.0.tgz#dfe797570d9694e560528d18eecad86c8c744899"
-  integrity sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==
-  dependencies:
-    "@typescript-eslint/scope-manager" "4.33.0"
-    "@typescript-eslint/types" "4.33.0"
-    "@typescript-eslint/typescript-estree" "4.33.0"
-    debug "^4.3.1"
-
-"@typescript-eslint/scope-manager@4.33.0":
-  version "4.33.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz#d38e49280d983e8772e29121cf8c6e9221f280a3"
-  integrity sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==
-  dependencies:
-    "@typescript-eslint/types" "4.33.0"
-    "@typescript-eslint/visitor-keys" "4.33.0"
-
-"@typescript-eslint/types@4.33.0":
-  version "4.33.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.33.0.tgz#a1e59036a3b53ae8430ceebf2a919dc7f9af6d72"
-  integrity sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==
-
-"@typescript-eslint/typescript-estree@4.33.0":
-  version "4.33.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz#0dfb51c2908f68c5c08d82aefeaf166a17c24609"
-  integrity sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==
-  dependencies:
-    "@typescript-eslint/types" "4.33.0"
-    "@typescript-eslint/visitor-keys" "4.33.0"
-    debug "^4.3.1"
-    globby "^11.0.3"
-    is-glob "^4.0.1"
-    semver "^7.3.5"
-    tsutils "^3.21.0"
-
-"@typescript-eslint/visitor-keys@4.33.0":
-  version "4.33.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz#2a22f77a41604289b7a186586e9ec48ca92ef1dd"
-  integrity sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==
-  dependencies:
-    "@typescript-eslint/types" "4.33.0"
-    eslint-visitor-keys "^2.0.0"
-
-acorn-jsx@^5.3.1:
-  version "5.3.2"
-  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
-  integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
-
-acorn@^7.4.0:
-  version "7.4.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
-  integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
-
-ajv@^6.10.0, ajv@^6.12.4:
-  version "6.12.6"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
-  integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
-  dependencies:
-    fast-deep-equal "^3.1.1"
-    fast-json-stable-stringify "^2.0.0"
-    json-schema-traverse "^0.4.1"
-    uri-js "^4.2.2"
-
-ajv@^8.0.1:
-  version "8.11.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.0.tgz#977e91dd96ca669f54a11e23e378e33b884a565f"
-  integrity sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==
-  dependencies:
-    fast-deep-equal "^3.1.1"
-    json-schema-traverse "^1.0.0"
-    require-from-string "^2.0.2"
-    uri-js "^4.2.2"
-
 ansi-colors@3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.3.tgz#57d35b8686e851e2cc04c403f1c00203976a1813"
   integrity sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==
-
-ansi-colors@^4.1.1:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.3.tgz#37611340eb2243e70cc604cad35d63270d48781b"
-  integrity sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==
 
 ansi-escapes@^3.1.0:
   version "3.2.0"
@@ -715,11 +332,6 @@ assertion-error@^1.1.0:
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
   integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
 
-astral-regex@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
-  integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
-
 async@^3.2.3:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.4.tgz#2d22e00f8cddeb5fde5dd33522b56d1cf569a81c"
@@ -771,16 +383,6 @@ browser-stdout@1.3.1:
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
   integrity sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
 
-browserslist@^4.21.3:
-  version "4.21.4"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.21.4.tgz#e7496bbc67b9e39dd0f98565feccdcb0d4ff6987"
-  integrity sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==
-  dependencies:
-    caniuse-lite "^1.0.30001400"
-    electron-to-chromium "^1.4.251"
-    node-releases "^2.0.6"
-    update-browserslist-db "^1.0.9"
-
 buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
@@ -791,25 +393,10 @@ builtin-modules@^1.1.1:
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
   integrity sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=
 
-builtin-modules@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.3.0.tgz#cae62812b89801e9656336e46223e030386be7b6"
-  integrity sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==
-
-callsites@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
-  integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
-
 camelcase@^5.0.0:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
-
-caniuse-lite@^1.0.30001400:
-  version "1.0.30001429"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001429.tgz#70cdae959096756a85713b36dd9cb82e62325639"
-  integrity sha512-511ThLu1hF+5RRRt0zYCf2U2yRr9GPF6m5y90SBCWsvSoYoW7yAGlv/elyPaNfvGCkp6kj/KFZWU0BMA69Prsg==
 
 cardinal@^2.1.1:
   version "2.1.1"
@@ -842,7 +429,7 @@ chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.0, chalk@^2.4.1:
+chalk@^2.0.1, chalk@^2.3.0, chalk@^2.4.1:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -851,7 +438,7 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.0, chalk@^2.4.1:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.0, chalk@^4.1.2:
+chalk@^4.0.2, chalk@^4.1.0, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -863,18 +450,6 @@ check-error@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
   integrity sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
-
-ci-info@^3.2.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.5.0.tgz#bfac2a29263de4c829d806b1ab478e35091e171f"
-  integrity sha512-yH4RezKOGlOhxkmhbeNuC4eYZKAUsEaGtBuBzDDP1eFUKiccDWzBABxBfOx31IDwDIXMTxWuwAxUGModvkbuVw==
-
-clean-regexp@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/clean-regexp/-/clean-regexp-1.0.0.tgz#8df7c7aae51fd36874e8f8d05b9180bc11a3fed7"
-  integrity sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==
-  dependencies:
-    escape-string-regexp "^1.0.5"
 
 clean-stack@^3.0.0, clean-stack@^3.0.1:
   version "3.0.1"
@@ -964,20 +539,10 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
-confusing-browser-globals@1.0.10:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz#30d1e7f3d1b882b25ec4933d1d1adac353d20a59"
-  integrity sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA==
-
 content-type@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
-
-convert-source-map@^1.7.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.9.0.tgz#7faae62353fb4213366d0ca98358d22e8368b05f"
-  integrity sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==
 
 cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
@@ -990,15 +555,6 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.2:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
-  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
-  dependencies:
-    path-key "^3.1.0"
-    shebang-command "^2.0.0"
-    which "^2.0.1"
-
 debug@3.2.6, debug@^3.1.0:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
@@ -1006,19 +562,19 @@ debug@3.2.6, debug@^3.1.0:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.0.1, debug@^4.3.1, debug@^4.3.4:
-  version "4.3.4"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
-  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
-  dependencies:
-    ms "2.1.2"
-
 debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
+
+debug@^4.3.4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
 
 decamelize@^1.2.0:
   version "1.2.0"
@@ -1036,11 +592,6 @@ deep-equal@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
   integrity sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=
-
-deep-is@^0.1.3:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
-  integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
 define-properties@^1.1.2, define-properties@^1.1.3:
   version "1.1.3"
@@ -1066,12 +617,13 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
-doctrine@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
-  integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
+doctrine@0.7.2:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-0.7.2.tgz#7cb860359ba3be90e040b26b729ce4bfa654c523"
+  integrity sha512-qiB/Rir6Un6Ad/TIgTRzsremsTGWzs8j7woXvp14jgq00676uBiBT5eUOi+FgRywZFVy5Us/c04ISRpZhRbS6w==
   dependencies:
-    esutils "^2.0.2"
+    esutils "^1.1.6"
+    isarray "0.0.1"
 
 ejs@^3.1.6:
   version "3.1.8"
@@ -1079,11 +631,6 @@ ejs@^3.1.6:
   integrity sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==
   dependencies:
     jake "^10.8.5"
-
-electron-to-chromium@^1.4.251:
-  version "1.4.284"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz#61046d1e4cab3a25238f6bf7413795270f125592"
-  integrity sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==
 
 emoji-regex@^7.0.1:
   version "7.0.3"
@@ -1094,13 +641,6 @@ emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
-
-enquirer@^2.3.5:
-  version "2.3.6"
-  resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
-  integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
-  dependencies:
-    ansi-colors "^4.1.1"
 
 error-ex@^1.3.1:
   version "1.3.2"
@@ -1135,242 +675,25 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-escalade@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
-  integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
-
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
-escape-string-regexp@4.0.0, escape-string-regexp@^4.0.0:
+escape-string-regexp@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
-
-eslint-config-oclif-typescript@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/eslint-config-oclif-typescript/-/eslint-config-oclif-typescript-1.0.3.tgz#0061a810bf8f69571ad3c70368badcc018c3358e"
-  integrity sha512-TeJKXWBQ3uKMtzgz++UFNWpe1WCx8mfqRuzZy1LirREgRlVv656SkVG4gNZat5rRNIQgfDmTS+YebxK02kfylA==
-  dependencies:
-    "@typescript-eslint/eslint-plugin" "^4.31.2"
-    "@typescript-eslint/parser" "^4.31.2"
-    eslint-config-xo-space "^0.29.0"
-    eslint-plugin-mocha "^9.0.0"
-    eslint-plugin-node "^11.1.0"
-
-eslint-config-oclif@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-oclif/-/eslint-config-oclif-4.0.0.tgz#90a07587f7be7c92ae3ce750ae11cf1e864239eb"
-  integrity sha512-5tkUQeC33rHAhJxaGeBGYIflDLumeV2qD/4XLBdXhB/6F/+Jnwdce9wYHSvkx0JUqUQShpQv8JEVkBp/zzD7hg==
-  dependencies:
-    eslint-config-xo-space "^0.27.0"
-    eslint-plugin-mocha "^9.0.0"
-    eslint-plugin-node "^11.1.0"
-    eslint-plugin-unicorn "^36.0.0"
-
-eslint-config-xo-space@^0.27.0:
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-xo-space/-/eslint-config-xo-space-0.27.0.tgz#9663e41d7bedc0f345488377770565aa9b0085e0"
-  integrity sha512-b8UjW+nQyOkhiANVpIptqlKPyE7XRyQ40uQ1NoBhzVfu95gxfZGrpliq8ZHBpaOF2wCLZaexTSjg7Rvm99vj4A==
-  dependencies:
-    eslint-config-xo "^0.35.0"
-
-eslint-config-xo-space@^0.29.0:
-  version "0.29.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-xo-space/-/eslint-config-xo-space-0.29.0.tgz#5bbd2d0ecb172c4e65022b8543ecb1f7d199b8e2"
-  integrity sha512-emUZVHjmzl3I1aO2M/2gEpqa/GHXTl7LF/vQeAX4W+mQIU+2kyqY97FkMnSc2J8Osoq+vCSXCY/HjFUmFIF/Ag==
-  dependencies:
-    eslint-config-xo "^0.38.0"
-
-eslint-config-xo@^0.35.0:
-  version "0.35.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-xo/-/eslint-config-xo-0.35.0.tgz#8b5afca244c44129c32386c28602f973ad5cb762"
-  integrity sha512-+WyZTLWUJlvExFrBU/Ldw8AB/S0d3x+26JQdBWbcqig2ZaWh0zinYcHok+ET4IoPaEcRRf3FE9kjItNVjBwnAg==
-  dependencies:
-    confusing-browser-globals "1.0.10"
-
-eslint-config-xo@^0.38.0:
-  version "0.38.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-xo/-/eslint-config-xo-0.38.0.tgz#50cbe676a90d5582e1bbf1de750286e7cf09378e"
-  integrity sha512-G2jL+VyfkcZW8GoTmqLsExvrWssBedSoaQQ11vyhflDeT3csMdBVp0On+AVijrRuvgmkWeDwwUL5Rj0qDRHK6g==
-  dependencies:
-    confusing-browser-globals "1.0.10"
-
-eslint-plugin-es@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz#75a7cdfdccddc0589934aeeb384175f221c57893"
-  integrity sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==
-  dependencies:
-    eslint-utils "^2.0.0"
-    regexpp "^3.0.0"
-
-eslint-plugin-mocha@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-mocha/-/eslint-plugin-mocha-9.0.0.tgz#b4457d066941eecb070dc06ed301c527d9c61b60"
-  integrity sha512-d7knAcQj1jPCzZf3caeBIn3BnW6ikcvfz0kSqQpwPYcVGLoJV5sz0l0OJB2LR8I7dvTDbqq1oV6ylhSgzA10zg==
-  dependencies:
-    eslint-utils "^3.0.0"
-    ramda "^0.27.1"
-
-eslint-plugin-node@^11.1.0:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz#c95544416ee4ada26740a30474eefc5402dc671d"
-  integrity sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==
-  dependencies:
-    eslint-plugin-es "^3.0.0"
-    eslint-utils "^2.0.0"
-    ignore "^5.1.1"
-    minimatch "^3.0.4"
-    resolve "^1.10.1"
-    semver "^6.1.0"
-
-eslint-plugin-unicorn@^36.0.0:
-  version "36.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-unicorn/-/eslint-plugin-unicorn-36.0.0.tgz#db50e1426839e401d33c5a279f49d4a5bbb640d8"
-  integrity sha512-xxN2vSctGWnDW6aLElm/LKIwcrmk6mdiEcW55Uv5krcrVcIFSWMmEgc/hwpemYfZacKZ5npFERGNz4aThsp1AA==
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.14.9"
-    ci-info "^3.2.0"
-    clean-regexp "^1.0.0"
-    eslint-template-visitor "^2.3.2"
-    eslint-utils "^3.0.0"
-    is-builtin-module "^3.1.0"
-    lodash "^4.17.21"
-    pluralize "^8.0.0"
-    read-pkg-up "^7.0.1"
-    regexp-tree "^0.1.23"
-    safe-regex "^2.1.1"
-    semver "^7.3.5"
-
-eslint-scope@5.1.1, eslint-scope@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
-  integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
-  dependencies:
-    esrecurse "^4.3.0"
-    estraverse "^4.1.1"
-
-eslint-template-visitor@^2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/eslint-template-visitor/-/eslint-template-visitor-2.3.2.tgz#b52f96ff311e773a345d79053ccc78275bbc463d"
-  integrity sha512-3ydhqFpuV7x1M9EK52BPNj6V0Kwu0KKkcIAfpUhwHbR8ocRln/oUHgfxQupY8O1h4Qv/POHDumb/BwwNfxbtnA==
-  dependencies:
-    "@babel/core" "^7.12.16"
-    "@babel/eslint-parser" "^7.12.16"
-    eslint-visitor-keys "^2.0.0"
-    esquery "^1.3.1"
-    multimap "^1.1.0"
-
-eslint-utils@^2.0.0, eslint-utils@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.1.0.tgz#d2de5e03424e707dc10c74068ddedae708741b27"
-  integrity sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
-  dependencies:
-    eslint-visitor-keys "^1.1.0"
-
-eslint-utils@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-3.0.0.tgz#8aebaface7345bb33559db0a1f13a1d2d48c3672"
-  integrity sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==
-  dependencies:
-    eslint-visitor-keys "^2.0.0"
-
-eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
-  integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
-
-eslint-visitor-keys@^2.0.0, eslint-visitor-keys@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
-  integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
-
-eslint@7.32.0:
-  version "7.32.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.32.0.tgz#c6d328a14be3fb08c8d1d21e12c02fdb7a2a812d"
-  integrity sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==
-  dependencies:
-    "@babel/code-frame" "7.12.11"
-    "@eslint/eslintrc" "^0.4.3"
-    "@humanwhocodes/config-array" "^0.5.0"
-    ajv "^6.10.0"
-    chalk "^4.0.0"
-    cross-spawn "^7.0.2"
-    debug "^4.0.1"
-    doctrine "^3.0.0"
-    enquirer "^2.3.5"
-    escape-string-regexp "^4.0.0"
-    eslint-scope "^5.1.1"
-    eslint-utils "^2.1.0"
-    eslint-visitor-keys "^2.0.0"
-    espree "^7.3.1"
-    esquery "^1.4.0"
-    esutils "^2.0.2"
-    fast-deep-equal "^3.1.3"
-    file-entry-cache "^6.0.1"
-    functional-red-black-tree "^1.0.1"
-    glob-parent "^5.1.2"
-    globals "^13.6.0"
-    ignore "^4.0.6"
-    import-fresh "^3.0.0"
-    imurmurhash "^0.1.4"
-    is-glob "^4.0.0"
-    js-yaml "^3.13.1"
-    json-stable-stringify-without-jsonify "^1.0.1"
-    levn "^0.4.1"
-    lodash.merge "^4.6.2"
-    minimatch "^3.0.4"
-    natural-compare "^1.4.0"
-    optionator "^0.9.1"
-    progress "^2.0.0"
-    regexpp "^3.1.0"
-    semver "^7.2.1"
-    strip-ansi "^6.0.0"
-    strip-json-comments "^3.1.0"
-    table "^6.0.9"
-    text-table "^0.2.0"
-    v8-compile-cache "^2.0.3"
-
-espree@^7.3.0, espree@^7.3.1:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-7.3.1.tgz#f2df330b752c6f55019f8bd89b7660039c1bbbb6"
-  integrity sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==
-  dependencies:
-    acorn "^7.4.0"
-    acorn-jsx "^5.3.1"
-    eslint-visitor-keys "^1.3.0"
 
 esprima@^4.0.0, esprima@~4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
-esquery@^1.3.1, esquery@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.4.0.tgz#2148ffc38b82e8c7057dfed48425b3e61f0f24a5"
-  integrity sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==
-  dependencies:
-    estraverse "^5.1.0"
-
-esrecurse@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.3.0.tgz#7ad7964d679abb28bee72cec63758b1c5d2c9921"
-  integrity sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
-  dependencies:
-    estraverse "^5.2.0"
-
-estraverse@^4.1.1:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
-  integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
-
-estraverse@^5.1.0, estraverse@^5.2.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
-  integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
+esutils@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/esutils/-/esutils-1.1.6.tgz#c01ccaa9ae4b897c6d0c3e210ae52f3c7a844375"
+  integrity sha512-RG1ZkUT7iFJG9LSHr7KDuuMSlujfeTtMNIcInURxKAxhMtwQhI3NrQhz26gZQYlsYZQKzsnwtpKrFKj9K9Qu1A==
 
 esutils@^2.0.2:
   version "2.0.3"
@@ -1409,11 +732,6 @@ fancy-test@^1.4.3:
     mock-stdin "^0.3.1"
     stdout-stderr "^0.1.9"
 
-fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
-  integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
-
 fast-glob@^3.2.9:
   version "3.2.12"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.12.tgz#7f39ec99c2e6ab030337142da9e0c18f37afae80"
@@ -1425,29 +743,12 @@ fast-glob@^3.2.9:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
-fast-json-stable-stringify@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
-  integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
-
-fast-levenshtein@^2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
-  integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
-
 fastq@^1.6.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.13.0.tgz#616760f88a7526bdfc596b7cab8c18938c36b98c"
   integrity sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==
   dependencies:
     reusify "^1.0.4"
-
-file-entry-cache@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027"
-  integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
-  dependencies:
-    flat-cache "^3.0.4"
 
 filelist@^1.0.1:
   version "1.0.4"
@@ -1478,33 +779,12 @@ find-up@3.0.0, find-up@^3.0.0:
   dependencies:
     locate-path "^3.0.0"
 
-find-up@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
-  integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
-  dependencies:
-    locate-path "^5.0.0"
-    path-exists "^4.0.0"
-
-flat-cache@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
-  integrity sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==
-  dependencies:
-    flatted "^3.1.0"
-    rimraf "^3.0.2"
-
 flat@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/flat/-/flat-4.1.0.tgz#090bec8b05e39cba309747f1d588f04dbaf98db2"
   integrity sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==
   dependencies:
     is-buffer "~2.0.3"
-
-flatted@^3.1.0:
-  version "3.2.7"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
-  integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
 fs-extra@^7.0.1:
   version "7.0.1"
@@ -1544,17 +824,7 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
-functional-red-black-tree@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
-  integrity sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==
-
-gensync@^1.0.0-beta.2:
-  version "1.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
-  integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
-
-get-caller-file@^2.0.1:
+get-caller-file@^2.0.0, get-caller-file@^2.0.1:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
@@ -1605,31 +875,7 @@ glob@^7.1.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.1.3:
-  version "7.2.3"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
-  integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.1.1"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-globals@^11.1.0:
-  version "11.12.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
-  integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
-
-globals@^13.6.0, globals@^13.9.0:
-  version "13.17.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-13.17.0.tgz#902eb1e680a41da93945adbdcb5a9f361ba69bd4"
-  integrity sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==
-  dependencies:
-    type-fest "^0.20.2"
-
-globby@^11.0.3, globby@^11.1.0:
+globby@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
   integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
@@ -1698,11 +944,6 @@ heroku-client@^3.1.0:
     is-retry-allowed "^1.0.0"
     tunnel-agent "^0.6.0"
 
-hosted-git-info@^2.1.4:
-  version "2.8.9"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
-  integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
-
 http-call@^5.2.4:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/http-call/-/http-call-5.3.0.tgz#4ded815b13f423de176eb0942d69c43b25b148db"
@@ -1720,28 +961,10 @@ hyperlinker@^1.0.0:
   resolved "https://registry.yarnpkg.com/hyperlinker/-/hyperlinker-1.0.0.tgz#23dc9e38a206b208ee49bc2d6c8ef47027df0c0e"
   integrity sha512-Ty8UblRWFEcfSuIaajM34LdPXIhbs1ajEX/BBPv24J+enSVaEVY63xQ6lTO9VRYS5LAoghIG0IDJ+p+IPzKUQQ==
 
-ignore@^4.0.6:
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
-  integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
-
-ignore@^5.1.1, ignore@^5.1.8, ignore@^5.2.0:
+ignore@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
-
-import-fresh@^3.0.0, import-fresh@^3.2.1:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
-  integrity sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==
-  dependencies:
-    parent-module "^1.0.0"
-    resolve-from "^4.0.0"
-
-imurmurhash@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
-  integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
 
 indent-string@^4.0.0:
   version "4.0.0"
@@ -1761,6 +984,11 @@ inherits@2:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
+inversify@^5.0.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/inversify/-/inversify-5.1.1.tgz#6fbd668c591337404e005a1946bfe0d802c08730"
+  integrity sha512-j8grHGDzv1v+8T1sAQ+3boTCntFPfvxLCkNcxB1J8qA0lUN+fAlSyYd+RXKvaPRL4AGyPxViutBEJHNXOyUdFQ==
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -1771,24 +999,10 @@ is-buffer@~2.0.3:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.4.tgz#3e572f23c8411a5cfd9557c849e3665e0b290623"
   integrity sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==
 
-is-builtin-module@^3.1.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-3.2.0.tgz#bb0310dfe881f144ca83f30100ceb10cf58835e0"
-  integrity sha512-phDA4oSGt7vl1n5tJvTWooWWAsXLY+2xCnxNqvKhGEzujg+A43wPlPOyDg3C8XQHN+6k/JTQWJ/j0dQh/qr+Hw==
-  dependencies:
-    builtin-modules "^3.3.0"
-
 is-callable@^1.1.4, is-callable@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.5.tgz#f7e46b596890456db74e7f6e976cb3273d06faab"
   integrity sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==
-
-is-core-module@^2.9.0:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.11.0.tgz#ad4cb3e3863e814523c96f3f58d26cc570ff0144"
-  integrity sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==
-  dependencies:
-    has "^1.0.3"
 
 is-date-object@^1.0.1:
   version "1.0.2"
@@ -1815,7 +1029,7 @@ is-fullwidth-code-point@^3.0.0:
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
-is-glob@^4.0.0, is-glob@^4.0.1:
+is-glob@^4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
@@ -1903,11 +1117,6 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-js-tokens@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
-  integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
-
 js-yaml@3.13.1, js-yaml@^3.7.0:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
@@ -1924,45 +1133,15 @@ js-yaml@^3.13.1, js-yaml@^3.14.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-jsesc@^2.5.1:
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
-  integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
-
 json-parse-better-errors@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
   integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
 
-json-parse-even-better-errors@^2.3.0:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
-  integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
-
-json-schema-traverse@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
-  integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
-
-json-schema-traverse@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
-  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
-
-json-stable-stringify-without-jsonify@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
-  integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
-
 json-stringify-safe@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
-
-json5@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
-  integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
 
 jsonfile@^4.0.0:
   version "4.0.0"
@@ -1985,19 +1164,6 @@ just-extend@^4.0.2:
   resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.0.2.tgz#f3f47f7dfca0f989c55410a7ebc8854b07108afc"
   integrity sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==
 
-levn@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
-  integrity sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==
-  dependencies:
-    prelude-ls "^1.2.1"
-    type-check "~0.4.0"
-
-lines-and-columns@^1.1.6:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
-  integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
-
 locate-path@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
@@ -2006,27 +1172,10 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
-locate-path@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
-  integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
-  dependencies:
-    p-locate "^4.1.0"
-
 lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
-
-lodash.merge@^4.6.2:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
-  integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
-
-lodash.truncate@^4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
-  integrity sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==
 
 lodash@^4.17.13, lodash@^4.17.15, lodash@^4.17.5:
   version "4.17.20"
@@ -2082,7 +1231,7 @@ minimatch@3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^3.0.4, minimatch@^3.1.1:
+minimatch@^3.0.4:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
@@ -2157,16 +1306,6 @@ ms@2.1.2, ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-multimap@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/multimap/-/multimap-1.1.0.tgz#5263febc085a1791c33b59bb3afc6a76a2a10ca8"
-  integrity sha512-0ZIR9PasPxGXmRsEF8jsDzndzHDj7tIav+JUmvIFB/WHswliFnquxECT/De7GR4yg99ky/NlRKJT82G1y271bw==
-
-natural-compare@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
-  integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
-
 natural-orderby@^2.0.1, natural-orderby@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/natural-orderby/-/natural-orderby-2.0.3.tgz#8623bc518ba162f8ff1cdb8941d74deb0fdcc016"
@@ -2218,21 +1357,6 @@ node-environment-flags@1.0.5:
   dependencies:
     object.getownpropertydescriptors "^2.0.3"
     semver "^5.7.0"
-
-node-releases@^2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.6.tgz#8a7088c63a55e493845683ebf3c828d8c51c5503"
-  integrity sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==
-
-normalize-package-data@^2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
-  integrity sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
-  dependencies:
-    hosted-git-info "^2.1.4"
-    resolve "^1.10.0"
-    semver "2 || 3 || 4 || 5"
-    validate-npm-package-license "^3.0.1"
 
 npm-run-path@^2.0.0:
   version "2.0.2"
@@ -2288,18 +1412,6 @@ open@^6.2.0:
   dependencies:
     is-wsl "^1.1.0"
 
-optionator@^0.9.1:
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.1.tgz#4f236a6373dae0566a6d43e1326674f50c291499"
-  integrity sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==
-  dependencies:
-    deep-is "^0.1.3"
-    fast-levenshtein "^2.0.6"
-    levn "^0.4.1"
-    prelude-ls "^1.2.1"
-    type-check "^0.4.0"
-    word-wrap "^1.2.3"
-
 p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
@@ -2312,13 +1424,6 @@ p-limit@^2.0.0:
   dependencies:
     p-try "^2.0.0"
 
-p-limit@^2.2.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
-  integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
-  dependencies:
-    p-try "^2.0.0"
-
 p-locate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
@@ -2326,24 +1431,10 @@ p-locate@^3.0.0:
   dependencies:
     p-limit "^2.0.0"
 
-p-locate@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-4.1.0.tgz#a3428bb7088b3a60292f66919278b7c297ad4f07"
-  integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
-  dependencies:
-    p-limit "^2.2.0"
-
 p-try@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
-
-parent-module@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
-  integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
-  dependencies:
-    callsites "^3.0.0"
 
 parse-json@^4.0.0:
   version "4.0.0"
@@ -2352,16 +1443,6 @@ parse-json@^4.0.0:
   dependencies:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
-
-parse-json@^5.0.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.2.0.tgz#c76fc66dee54231c962b22bcc8a72cf2f99753cd"
-  integrity sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    error-ex "^1.3.1"
-    json-parse-even-better-errors "^2.3.0"
-    lines-and-columns "^1.1.6"
 
 password-prompt@^1.1.2:
   version "1.1.2"
@@ -2376,11 +1457,6 @@ path-exists@^3.0.0:
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
   integrity sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=
 
-path-exists@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
-  integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
-
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
@@ -2391,20 +1467,10 @@ path-key@^2.0.0, path-key@^2.0.1:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
   integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
 
-path-key@^3.1.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
-  integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
-
 path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
-
-path-parse@^1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
-  integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
 path-to-regexp@^1.7.0:
   version "1.8.0"
@@ -2423,30 +1489,10 @@ pathval@^1.1.0:
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
   integrity sha1-uULm1L3mUwBe9rcTYd74cn0GReA=
 
-picocolors@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
-  integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
-
 picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
-
-pluralize@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
-  integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
-
-prelude-ls@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
-  integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
-
-progress@^2.0.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
-  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
 propagate@^1.0.0:
   version "1.0.0"
@@ -2462,11 +1508,6 @@ proxyquire@^2.1.0:
     module-not-found-error "^1.0.1"
     resolve "^1.11.1"
 
-punycode@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
-  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
-
 qs@^6.5.1:
   version "6.6.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.6.0.tgz#a99c0f69a8d26bf7ef012f871cdabb0aee4424c2"
@@ -2477,30 +1518,6 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
-ramda@^0.27.1:
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.2.tgz#84463226f7f36dc33592f6f4ed6374c48306c3f1"
-  integrity sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA==
-
-read-pkg-up@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-7.0.1.tgz#f3a6135758459733ae2b95638056e1854e7ef507"
-  integrity sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==
-  dependencies:
-    find-up "^4.1.0"
-    read-pkg "^5.2.0"
-    type-fest "^0.8.1"
-
-read-pkg@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-5.2.0.tgz#7bf295438ca5a33e56cd30e053b34ee7250c93cc"
-  integrity sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==
-  dependencies:
-    "@types/normalize-package-data" "^2.4.0"
-    normalize-package-data "^2.5.0"
-    parse-json "^5.0.0"
-    type-fest "^0.6.0"
-
 redeyed@~2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/redeyed/-/redeyed-2.1.1.tgz#8984b5815d99cb220469c99eeeffe38913e6cc0b"
@@ -2508,44 +1525,20 @@ redeyed@~2.1.0:
   dependencies:
     esprima "~4.0.0"
 
-regexp-tree@^0.1.23, regexp-tree@~0.1.1:
-  version "0.1.24"
-  resolved "https://registry.yarnpkg.com/regexp-tree/-/regexp-tree-0.1.24.tgz#3d6fa238450a4d66e5bc9c4c14bb720e2196829d"
-  integrity sha512-s2aEVuLhvnVJW6s/iPgEGK6R+/xngd2jNQ+xy4bXNDKxZKJH6jpPHY6kVeVv1IeLCHgswRj+Kl3ELaDjG6V1iw==
-
-regexpp@^3.0.0, regexpp@^3.1.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
-  integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
+reflect-metadata@^0.1.12:
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
+  integrity sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==
 
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
 
-require-from-string@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
-  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
-
 require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
-
-resolve-from@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
-  integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
-
-resolve@^1.10.0, resolve@^1.10.1:
-  version "1.22.1"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
-  integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
-  dependencies:
-    is-core-module "^2.9.0"
-    path-parse "^1.0.7"
-    supports-preserve-symlinks-flag "^1.0.0"
 
 resolve@^1.11.1, resolve@^1.3.2:
   version "1.15.0"
@@ -2559,13 +1552,6 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-rimraf@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
-  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
-  dependencies:
-    glob "^7.1.3"
-
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
@@ -2578,24 +1564,12 @@ safe-buffer@^5.0.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
   integrity sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==
 
-safe-regex@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/safe-regex/-/safe-regex-2.1.1.tgz#f7128f00d056e2fe5c11e81a1324dd974aadced2"
-  integrity sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==
-  dependencies:
-    regexp-tree "~0.1.1"
-
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.5.0, semver@^5.7.0:
+semver@^5.3.0, semver@^5.5.0, semver@^5.7.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@^6.1.0, semver@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
-  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
-
-semver@^7.2.1, semver@^7.3.2, semver@^7.3.5, semver@^7.3.7:
+semver@^7.3.2, semver@^7.3.7:
   version "7.3.8"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
   integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
@@ -2614,22 +1588,10 @@ shebang-command@^1.2.0:
   dependencies:
     shebang-regex "^1.0.0"
 
-shebang-command@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
-  integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
-  dependencies:
-    shebang-regex "^3.0.0"
-
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==
-
-shebang-regex@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
-  integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
 signal-exit@^3.0.0:
   version "3.0.2"
@@ -2654,15 +1616,6 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
-slice-ansi@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-4.0.0.tgz#500e8dd0fd55b05815086255b3195adf2a45fe6b"
-  integrity sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==
-  dependencies:
-    ansi-styles "^4.0.0"
-    astral-regex "^2.0.0"
-    is-fullwidth-code-point "^3.0.0"
-
 source-map-support@^0.5.6:
   version "0.5.16"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.16.tgz#0ae069e7fe3ba7538c64c98515e35339eac5a042"
@@ -2675,32 +1628,6 @@ source-map@^0.6.0:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
-
-spdx-correct@^3.0.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.1.1.tgz#dece81ac9c1e6713e5f7d1b6f17d468fa53d89a9"
-  integrity sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==
-  dependencies:
-    spdx-expression-parse "^3.0.0"
-    spdx-license-ids "^3.0.0"
-
-spdx-exceptions@^2.1.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz#3f28ce1a77a00372683eade4a433183527a2163d"
-  integrity sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==
-
-spdx-expression-parse@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz#cf70f50482eefdc98e3ce0a6833e4a53ceeba679"
-  integrity sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==
-  dependencies:
-    spdx-exceptions "^2.1.0"
-    spdx-license-ids "^3.0.0"
-
-spdx-license-ids@^3.0.0:
-  version "3.0.12"
-  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz#69077835abe2710b65f03969898b6637b505a779"
-  integrity sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -2795,11 +1722,6 @@ strip-json-comments@2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
-strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
-  integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
-
 supports-color@6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-6.0.0.tgz#76cfe742cf1f41bb9b1c29ad03068c05b4c0e40a"
@@ -2841,32 +1763,6 @@ supports-hyperlinks@^2.1.0, supports-hyperlinks@^2.2.0:
     has-flag "^4.0.0"
     supports-color "^7.0.0"
 
-supports-preserve-symlinks-flag@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
-  integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
-
-table@^6.0.9:
-  version "6.8.0"
-  resolved "https://registry.yarnpkg.com/table/-/table-6.8.0.tgz#87e28f14fa4321c3377ba286f07b79b281a3b3ca"
-  integrity sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==
-  dependencies:
-    ajv "^8.0.1"
-    lodash.truncate "^4.4.2"
-    slice-ansi "^4.0.0"
-    string-width "^4.2.3"
-    strip-ansi "^6.0.1"
-
-text-table@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
-  integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
-
-to-fast-properties@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
-  integrity sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==
-
 to-regex-range@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
@@ -2885,6 +1781,16 @@ ts-node@^8.1.0:
     source-map-support "^0.5.6"
     yn "3.1.1"
 
+tslib@1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
+  integrity sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==
+
+tslib@^1.7.1:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
 tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.3:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
@@ -2899,6 +1805,40 @@ tslint-config-prettier@*:
   version "1.18.0"
   resolved "https://registry.yarnpkg.com/tslint-config-prettier/-/tslint-config-prettier-1.18.0.tgz#75f140bde947d35d8f0d238e0ebf809d64592c37"
   integrity sha512-xPw9PgNPLG3iKRxmK7DWr+Ea/SzrvfHtjFt5LBl61gk2UBG/DB9kCXRjv+xyIU1rUtnayLeMUVJBcMX8Z17nDg==
+
+tslint-consistent-codestyle@^1.11.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/tslint-consistent-codestyle/-/tslint-consistent-codestyle-1.16.0.tgz#52348ea899a7e025b37cc6545751c6a566a19077"
+  integrity sha512-ebR/xHyMEuU36hGNOgCfjGBNYxBPixf0yU1Yoo6s3BrpBRFccjPOmIVaVvQsWAUAMdmfzHOCihVkcaMfimqvHw==
+  dependencies:
+    "@fimbul/bifrost" "^0.21.0"
+    tslib "^1.7.1"
+    tsutils "^2.29.0"
+
+tslint-eslint-rules@^5.3.1, tslint-eslint-rules@^5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/tslint-eslint-rules/-/tslint-eslint-rules-5.4.0.tgz#e488cc9181bf193fe5cd7bfca213a7695f1737b5"
+  integrity sha512-WlSXE+J2vY/VPgIcqQuijMQiel+UtmXS+4nvK4ZzlDiqBfXse8FAvkNnTcYhnQyOTW5KFM+uRRGXxYhFpuBc6w==
+  dependencies:
+    doctrine "0.7.2"
+    tslib "1.9.0"
+    tsutils "^3.0.0"
+
+tslint-microsoft-contrib@^5.0.2:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/tslint-microsoft-contrib/-/tslint-microsoft-contrib-5.2.1.tgz#a6286839f800e2591d041ea2800c77487844ad81"
+  integrity sha512-PDYjvpo0gN9IfMULwKk0KpVOPMhU6cNoT9VwCOLeDl/QS8v8W2yspRpFFuUS7/c5EIH/n8ApMi8TxJAz1tfFUA==
+  dependencies:
+    tsutils "^2.27.2 <2.29.0"
+
+tslint-xo@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/tslint-xo/-/tslint-xo-0.9.0.tgz#e1faa505fecd5ac705460fc9f5ca417c3036c14f"
+  integrity sha512-Zk5jBdQVUaHEmR9TUoh1TJOjjCr7/nRplA+jDZBvucyBMx65pt0unTr6H/0HvrtSlucFvOMYsyBZE1W8b4AOig==
+  dependencies:
+    tslint-consistent-codestyle "^1.11.0"
+    tslint-eslint-rules "^5.3.1"
+    tslint-microsoft-contrib "^5.0.2"
 
 tslint@^5.8.0:
   version "5.13.1"
@@ -2919,14 +1859,21 @@ tslint@^5.8.0:
     tslib "^1.8.0"
     tsutils "^2.27.2"
 
-tsutils@^2.27.2:
+tsutils@^2.27.2, tsutils@^2.29.0:
   version "2.29.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.29.0.tgz#32b488501467acbedd4b85498673a0812aca0b99"
   integrity sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==
   dependencies:
     tslib "^1.8.1"
 
-tsutils@^3.21.0:
+"tsutils@^2.27.2 <2.29.0":
+  version "2.28.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.28.0.tgz#6bd71e160828f9d019b6f4e844742228f85169a1"
+  integrity sha512-bh5nAtW0tuhvOJnx1GLRn5ScraRLICGyJV5wJhtRWOLsxW70Kk5tZtpK3O/hW6LDnqKS9mlUMPZj9fEMJ0gxqA==
+  dependencies:
+    tslib "^1.8.1"
+
+tsutils@^3.0.0, tsutils@^3.5.0:
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
   integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
@@ -2940,37 +1887,15 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
-type-check@^0.4.0, type-check@~0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"
-  integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
-  dependencies:
-    prelude-ls "^1.2.1"
-
 type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5, type-detect@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
-type-fest@^0.20.2:
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
-  integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
-
 type-fest@^0.21.3:
   version "0.21.3"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
-
-type-fest@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
-  integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
-
-type-fest@^0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
-  integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
 typescript@^4.8.4:
   version "4.8.4"
@@ -2987,38 +1912,10 @@ universalify@^2.0.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
   integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
-update-browserslist-db@^1.0.9:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz#0f54b876545726f17d00cd9a2561e6dade943ff3"
-  integrity sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==
-  dependencies:
-    escalade "^3.1.1"
-    picocolors "^1.0.0"
-
-uri-js@^4.2.2:
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
-  integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
-  dependencies:
-    punycode "^2.1.0"
-
 uuid@^8.3.0:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.0.tgz#ab738085ca22dc9a8c92725e459b1d507df5d6ea"
   integrity sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==
-
-v8-compile-cache@^2.0.3:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
-  integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
-
-validate-npm-package-license@^3.0.1:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
-  integrity sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==
-  dependencies:
-    spdx-correct "^3.0.0"
-    spdx-expression-parse "^3.0.0"
 
 which-module@^2.0.0:
   version "2.0.0"
@@ -3029,13 +1926,6 @@ which@1.3.1, which@^1.2.9:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
-  dependencies:
-    isexe "^2.0.0"
-
-which@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
-  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
 
@@ -3052,11 +1942,6 @@ widest-line@^3.1.0:
   integrity sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==
   dependencies:
     string-width "^4.0.0"
-
-word-wrap@^1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
-  integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
 
 wrap-ansi@^5.1.0:
   version "5.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -342,7 +342,7 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@oclif/core@^1.20.4":
+"@oclif/core@^1.1.1", "@oclif/core@^1.20.4":
   version "1.20.4"
   resolved "https://registry.yarnpkg.com/@oclif/core/-/core-1.20.4.tgz#7378b52e1f1b502e383ffb07f95dffc9fd8588ff"
   integrity sha512-giug32M4YhSYNYKQwE1L57/+k5gp1+Bq3/0vKNQmzAY1tizFGhvBJc6GIRZasHjU+xtZLutQvrVrJo7chX3hxg==
@@ -380,6 +380,11 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@oclif/linewrap/-/linewrap-1.0.0.tgz#aedcb64b479d4db7be24196384897b5000901d91"
   integrity sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw==
+
+"@oclif/screen@^1.0.4 ":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@oclif/screen/-/screen-1.0.4.tgz#b740f68609dfae8aa71c3a6cab15d816407ba493"
+  integrity sha512-60CHpq+eqnTxLZQ4PGHYNwUX572hgpMHGPtTWMjdTMsAvlm69lZV/4ly6O3sAYkomo4NggGcomrDpBe34rxUqw==
 
 "@oclif/screen@^3.0.3":
   version "3.0.3"
@@ -637,7 +642,7 @@ ansi-escapes@^3.1.0:
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
   integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
 
-ansi-escapes@^4.3.2:
+ansi-escapes@^4.3.0, ansi-escapes@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.2.tgz#6b2291d1db7d98b6521d5f1efa42d0f3a9feb65e"
   integrity sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==
@@ -676,7 +681,7 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
-ansi-styles@^4.0.0, ansi-styles@^4.1.0, ansi-styles@^4.3.0:
+ansi-styles@^4.0.0, ansi-styles@^4.1.0, ansi-styles@^4.2.0, ansi-styles@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
@@ -846,7 +851,7 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.0, chalk@^2.4.1:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.2:
+chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.0, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -871,7 +876,7 @@ clean-regexp@^1.0.0:
   dependencies:
     escape-string-regexp "^1.0.5"
 
-clean-stack@^3.0.1:
+clean-stack@^3.0.0, clean-stack@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-3.0.1.tgz#155bf0b2221bf5f4fba89528d24c5953f17fe3a8"
   integrity sha512-lR9wNiMRcVQjSB3a7xXGLuz4cr4wJuuXlaAEbRutGowQTmlp7R72/DOgN21e8jdwblMWl9UOJMJXarX94pzKdg==
@@ -884,6 +889,37 @@ cli-progress@^3.10.0:
   integrity sha512-lCPoS6ncgX4+rJu5bS3F/iCz17kZ9MPZ6dpuTtI0KXKABkhyXIdYB3Inby1OpaGti3YlI3EeEkM9AuWpelJrVA==
   dependencies:
     string-width "^4.2.3"
+
+cli-ux@^6.0.9:
+  version "6.0.9"
+  resolved "https://registry.yarnpkg.com/cli-ux/-/cli-ux-6.0.9.tgz#b5ab690314348b45b2c7458dad7621ae1be7c61d"
+  integrity sha512-0Ku29QLf+P6SeBNWM7zyoJ49eKKOjxZBZ4OH2aFeRtC0sNXU3ftdJxQPKJ1SJ+axX34I1NsfTFahpXdnxklZgA==
+  dependencies:
+    "@oclif/core" "^1.1.1"
+    "@oclif/linewrap" "^1.0.0"
+    "@oclif/screen" "^1.0.4 "
+    ansi-escapes "^4.3.0"
+    ansi-styles "^4.2.0"
+    cardinal "^2.1.1"
+    chalk "^4.1.0"
+    clean-stack "^3.0.0"
+    cli-progress "^3.10.0"
+    extract-stack "^2.0.0"
+    fs-extra "^8.1"
+    hyperlinker "^1.0.0"
+    indent-string "^4.0.0"
+    is-wsl "^2.2.0"
+    js-yaml "^3.13.1"
+    lodash "^4.17.21"
+    natural-orderby "^2.0.1"
+    object-treeify "^1.1.4"
+    password-prompt "^1.1.2"
+    semver "^7.3.2"
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    supports-color "^8.1.0"
+    supports-hyperlinks "^2.1.0"
+    tslib "^2.0.0"
 
 cliui@^5.0.0:
   version "5.0.0"
@@ -1354,6 +1390,11 @@ execa@^0.10.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+extract-stack@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/extract-stack/-/extract-stack-2.0.0.tgz#11367bc865bfcd9bc0db3123e5edb57786f11f9b"
+  integrity sha512-AEo4zm+TenK7zQorGK1f9mJ8L14hnTDi2ZQPR+Mub1NX8zimka1mXpV5LpH8x9HoUmFSHZCfLHqWvp0Y4FxxzQ==
+
 fancy-test@^1.4.3:
   version "1.4.7"
   resolved "https://registry.yarnpkg.com/fancy-test/-/fancy-test-1.4.7.tgz#2a9fa5de970fad65b3d27228d9904545524d0550"
@@ -1471,6 +1512,15 @@ fs-extra@^7.0.1:
   integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
   dependencies:
     graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
+fs-extra@^8.1:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
+  integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
+  dependencies:
+    graceful-fs "^4.2.0"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
@@ -2117,7 +2167,7 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-natural-orderby@^2.0.3:
+natural-orderby@^2.0.1, natural-orderby@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/natural-orderby/-/natural-orderby-2.0.3.tgz#8623bc518ba162f8ff1cdb8941d74deb0fdcc016"
   integrity sha512-p7KTHxU0CUrcOXe62Zfrb5Z13nLvPhSWR/so3kFulUQU0sgUll2Z0LwpsLN351eOOD+hRGu/F1g+6xDfPeD++Q==
@@ -2201,7 +2251,7 @@ object-keys@^1.0.11, object-keys@^1.0.12, object-keys@^1.1.1:
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
 
-object-treeify@^1.1.33:
+object-treeify@^1.1.33, object-treeify@^1.1.4:
   version "1.1.33"
   resolved "https://registry.yarnpkg.com/object-treeify/-/object-treeify-1.1.33.tgz#f06fece986830a3cba78ddd32d4c11d1f76cdf40"
   integrity sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A==
@@ -2545,7 +2595,7 @@ semver@^6.1.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.2.1, semver@^7.3.5, semver@^7.3.7:
+semver@^7.2.1, semver@^7.3.2, semver@^7.3.5, semver@^7.3.7:
   version "7.3.8"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
   integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
@@ -2682,7 +2732,7 @@ string-width@^3.0.0, string-width@^3.1.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
-string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.3:
+string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -2776,14 +2826,14 @@ supports-color@^7.0.0, supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-supports-color@^8.1.1:
+supports-color@^8.1.0, supports-color@^8.1.1:
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
   integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
   dependencies:
     has-flag "^4.0.0"
 
-supports-hyperlinks@^2.2.0:
+supports-hyperlinks@^2.1.0, supports-hyperlinks@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz#3943544347c1ff90b15effb03fc14ae45ec10624"
   integrity sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==
@@ -2840,7 +2890,7 @@ tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
 
-tslib@^2.4.1:
+tslib@^2.0.0, tslib@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
   integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,27 @@
 # yarn lockfile v1
 
 
+"@babel/code-frame@^7.0.0":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.18.6.tgz#3b25d38c89600baa2dcc219edfa88a74eb2c427a"
+  integrity sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==
+  dependencies:
+    "@babel/highlight" "^7.18.6"
+
+"@babel/helper-validator-identifier@^7.18.6":
+  version "7.19.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz#7eea834cf32901ffdc1a7ee555e2f9c27e249ca2"
+  integrity sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==
+
+"@babel/highlight@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.18.6.tgz#81158601e93e2563795adcbfbdf5d64be3f2ecdf"
+  integrity sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.18.6"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
+
 "@fimbul/bifrost@^0.21.0":
   version "0.21.0"
   resolved "https://registry.yarnpkg.com/@fimbul/bifrost/-/bifrost-0.21.0.tgz#d0fafa25938fda475657a6a1e407a21bbe02c74e"
@@ -429,7 +450,7 @@ chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.1, chalk@^2.3.0, chalk@^2.4.1:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.0, chalk@^2.4.1:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -1117,6 +1138,11 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
+js-tokens@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+  integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
+
 js-yaml@3.13.1, js-yaml@^3.7.0:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
@@ -1250,12 +1276,24 @@ minimist@0.0.8:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
   integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
 
+minimist@^1.2.6:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.7.tgz#daa1c4d91f507390437c6a8bc01078e7000c4d18"
+  integrity sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==
+
 mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
+
+mkdirp@^0.5.3:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
+  integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
+  dependencies:
+    minimist "^1.2.6"
 
 mocha@^6.1.4:
   version "6.2.2"
@@ -1786,7 +1824,7 @@ tslib@1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
   integrity sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==
 
-tslib@^1.7.1:
+tslib@^1.13.0, tslib@^1.7.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
@@ -1858,6 +1896,25 @@ tslint@^5.8.0:
     semver "^5.3.0"
     tslib "^1.8.0"
     tsutils "^2.27.2"
+
+tslint@^6.1.3:
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-6.1.3.tgz#5c23b2eccc32487d5523bd3a470e9aa31789d904"
+  integrity sha512-IbR4nkT96EQOvKE2PW/djGz8iGNeJ4rF2mBfiYaR/nvUWYKJhLwimoJKgjIFEIDibBtOevj7BqCRL4oHeWWUCg==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    builtin-modules "^1.1.1"
+    chalk "^2.3.0"
+    commander "^2.12.1"
+    diff "^4.0.1"
+    glob "^7.1.1"
+    js-yaml "^3.13.1"
+    minimatch "^3.0.4"
+    mkdirp "^0.5.3"
+    resolve "^1.3.2"
+    semver "^5.3.0"
+    tslib "^1.13.0"
+    tsutils "^2.29.0"
 
 tsutils@^2.27.2, tsutils@^2.29.0:
   version "2.29.0"


### PR DESCRIPTION
Fix remaining packages and tests.
Added `cli-ux` dependency back for believed intended purpose `deprecatedCLI`
Revert back to tslint from eslint.
