### PR TITLE
fix: fix pjson import and remove option from tsconfig

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -1,7 +1,7 @@
 import {Command as Base} from '@oclif/core'
 import {deprecate} from 'util'
 
-import pjson from '../package.json'
+const pjson = require('../package.json')
 
 import {APIClient} from './api-client'
 import deps from './deps'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
     "declaration": true,
     "forceConsistentCasingInFileNames": true,
     "esModuleInterop": true,
-    "resolveJsonModule": true,
     "importHelpers": true,
     "module": "commonjs",
     "outDir": "./lib",


### PR DESCRIPTION
Fixes an issue with the `build` command that would output the files in the `src` directory into a `src` directory inside the `lib` directory, instead of directly inside the `lib` directory. See [Slack convo](https://salesforce-internal.slack.com/archives/C01LKDT1P6J/p1669239615684489) for more info.