### PR TITLE
chore: update gh actions/checkout to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         node-version: lts/*
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
Updating GH actions/checkout to use v3