### PR TITLE
chore: update gh actions CI config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,14 +5,16 @@ on:
 
 jobs:
   test:
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js LTS versions
         uses: actions/setup-node@v3
         with:
-          node-version: lts/*
-          yarn: cache
+          node-version: 12.x
       - run: yarn --frozen-lockfile --network-timeout 1000000
         env:
           CI: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,11 @@ on:
   push
 
 jobs:
-  build:
+  test:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [windows-latest, ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js LTS versions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         os: [windows-latest, ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js LTS versions
+      - name: Use Node.js 17
         uses: actions/setup-node@v3
         with:
           node-version: 17.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,7 @@ on:
 
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js LTS versions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Use Node.js LTS versions
         uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 17.x
       - run: yarn --frozen-lockfile --network-timeout 1000000
         env:
           CI: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,24 +1,22 @@
-name: Windows Node.js
+name: Node CI Suite
 
 on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+  push
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - name: Use Node.js LTS versions
+        uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
-      - run: yarn install
+          node-version: lts/*
+          yarn: cache
+      - run: yarn --frozen-lockfile --network-timeout 1000000
         env:
           CI: true
       - run: yarn test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,14 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
+        node-version: [lts/gallium, lts/fermium, lts/erbium, lts/dubnium]
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js 17
+      - name: Use Node.js LTS versions (v10-v16)
         uses: actions/setup-node@v3
         with:
-          node-version: 17.x
+          node-version: ${{ matrix.node-version }}
+          cache: yarn
       - run: yarn --frozen-lockfile --network-timeout 1000000
         env:
           CI: true


### PR DESCRIPTION
Updating our GH actions CI config so that it
- runs on push to all branches
- runs against windows, ubuntu, and macos
- uses v3 of both actions/checkout and actions/setup-node
- uses node version 17