### PR TITLE
fix(W-16338640): Update logic for backwards compatibility for CLI commands

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -59,7 +59,7 @@ export abstract class Command extends Base {
         const nonExistentFlagsWithValues = {...parsed}
 
         if (nonExistentFlags && nonExistentFlags.length > 0) {
-          this.warn(`You’re using a deprecated syntax with the [${nonExistentFlags}] flag.\nAdd a '--' (end of options) separator before the flags you’re passing through.\nSee https://devcenter.heroku.com/changelog-items/2925 for more info.`)
+          this.warn(`You’re using a deprecated syntax with the [${nonExistentFlags}] flag.\nAdd a '--' (end of options) separator before the flags you’re passing through.`)
           for (const flag of nonExistentFlags) {
             const key = flag.replace('--', '')
             delete parsed[key]

--- a/src/command.ts
+++ b/src/command.ts
@@ -59,7 +59,7 @@ export abstract class Command extends Base {
         const nonExistentFlagsWithValues = {...parsed}
 
         if (nonExistentFlags && nonExistentFlags.length > 0) {
-          this.warn(`Using [${nonExistentFlags}] without a '--' (end of options) preceeding them is deprecated. Please use '--' preceeding the flag(s) meant to be passed-though.`)
+          this.warn(`You’re using a deprecated syntax with the [${nonExistentFlags}] flag.\nAdd a '--' (end of options) separator before the flags you’re passing through.\nSee https://devcenter.heroku.com/changelog-items/2925 for more info.`)
           for (const flag of nonExistentFlags) {
             const key = flag.replace('--', '')
             delete parsed[key]

--- a/src/command.ts
+++ b/src/command.ts
@@ -77,29 +77,21 @@ export abstract class Command extends Base {
         result.nonExistentFlags = unparser(nonExistentFlagsWithValues as unparser.Arguments)
 
         for (let index = 0; index < result.nonExistentFlags.length; index++) {
-          console.log('INDEX', index)
           const positionalValue = result.nonExistentFlags[index]
           const doubleHyphenRegex = /^--/
           const positionalValueIsFlag = doubleHyphenRegex.test(positionalValue)
-          // result.argv.push(positionalFlag)
           if (positionalValueIsFlag) {
-            // positionalValue = positionalValue.replace('--', '')
             const nextElement = result.nonExistentFlags[index + 1] ? result.nonExistentFlags[index + 1] : ''
             const nextElementIsFlag = doubleHyphenRegex.test(nextElement)
-            console.log('nextElement', nextElement)
-            console.log('nextElementIsFlag', nextElementIsFlag)
             // eslint-disable-next-line max-depth
             if (nextElement && !nextElementIsFlag) {
               result.argv.push(`${positionalValue}=${nextElement}`)
             } else if (!nextElement || nextElementIsFlag) {
               result.argv.push(`${positionalValue}=${true}`)
             }
-            // result.flags.positionalValue = 'test'
-            // result.argv.push(positionalValue)
           }
         }
 
-        console.log('RESULT', result)
         return result
       }
     }

--- a/src/command.ts
+++ b/src/command.ts
@@ -75,6 +75,31 @@ export abstract class Command extends Base {
         this.argv = unparser(parsed as unparser.Arguments)
         const result = await super.parse(options, argv)
         result.nonExistentFlags = unparser(nonExistentFlagsWithValues as unparser.Arguments)
+
+        for (let index = 0; index < result.nonExistentFlags.length; index++) {
+          console.log('INDEX', index)
+          const positionalValue = result.nonExistentFlags[index]
+          const doubleHyphenRegex = /^--/
+          const positionalValueIsFlag = doubleHyphenRegex.test(positionalValue)
+          // result.argv.push(positionalFlag)
+          if (positionalValueIsFlag) {
+            // positionalValue = positionalValue.replace('--', '')
+            const nextElement = result.nonExistentFlags[index + 1] ? result.nonExistentFlags[index + 1] : ''
+            const nextElementIsFlag = doubleHyphenRegex.test(nextElement)
+            console.log('nextElement', nextElement)
+            console.log('nextElementIsFlag', nextElementIsFlag)
+            // eslint-disable-next-line max-depth
+            if (nextElement && !nextElementIsFlag) {
+              result.argv.push(`${positionalValue}=${nextElement}`)
+            } else if (!nextElement || nextElementIsFlag) {
+              result.argv.push(`${positionalValue}=${true}`)
+            }
+            // result.flags.positionalValue = 'test'
+            // result.argv.push(positionalValue)
+          }
+        }
+
+        console.log('RESULT', result)
         return result
       }
     }


### PR DESCRIPTION
## Description
This PR fixes a bug discovered in the backwards compatibility logic where the passed positional flags aren't consumed by the `heroku addons:create` command. While this logic enables the proper consumption of positional flags, it should be noted that this implementation is temporary until the next major release of the Heroku CLI. The `nonExistentFlags` property values in the parsed result needed to be appended to the parsed results' `argv` property. In addition, copy for the deprecation warning has been updated as well.

## Testing
1. Pull down branch
2. Run `yarn && yarn build`
3. Link `heroku-cli-command` to local `Heroku CLI` via
Update `heroku/cli`'s `package.json` with `"@heroku-cli/command": "file:/path/to/local/heroku-cli-command",`
4. After saving the updated code, run `yarn && yarn prepack` from the `~cli/packages/cli` directory
5. Add the following below line 79 in the `create.ts` file for `addons`
`console.log('CONFIG', Object.entries(config))`
6. Run save code and run `yarn prepack`
7. Confirm passing positional arguments using old `v8.x.x` syntax via
`./bin/run addons:create -a heroku-cli-test-staging  heroku-postgresql:private-0 --follow DATABASE`
8. Ensure positional flags are properly logged from the `console.log()`
9. Confirm that the addon successfully provisioned a follower database with the positional `--follow` flag
10. Once finished, remove any test provisioned addons to the aforementioned app used
11. Remember to revert your `package.json` back once finished to unlink your local `heroku-cli-command` module