### PR TITLE
Adding missing debug and warning behaviors to APIClient

### DIFF
--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -120,9 +120,9 @@ export class APIClient {
       static showWarnings<T>(response: HTTP<T>) {
         const warnings = response.headers['x-heroku-warning'] || response.headers['warning-message']
         if (Array.isArray(warnings))
-          warnings.forEach(warning => warn(warning))
+          warnings.forEach(warning => warn(`${warning}\n`))
         else if (typeof warnings === 'string')
-          warn(warnings)
+          warn(`${warnings}\n`)
       }
 
       static configDelinquency(url: string, opts: APIClient.Options): void {

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -11,6 +11,8 @@ import {RequestId, requestIdHeader} from './request-id'
 import {vars} from './vars'
 import {ParticleboardClient, IDelinquencyInfo, IDelinquencyConfig} from './particleboard-client'
 
+const debug = require('debug')
+
 export namespace APIClient {
   export interface Options extends HTTPRequestOptions {
     retryAuth?: boolean
@@ -20,6 +22,8 @@ export namespace APIClient {
 export interface IOptions {
   required?: boolean
   preauth?: boolean
+  debug?: boolean
+  debugHeaders?: boolean
 }
 
 export interface IHerokuAPIErrorOptions {
@@ -63,6 +67,8 @@ export class APIClient {
 
     if (options.required === undefined) options.required = true
     options.preauth = options.preauth !== false
+    if (options.debug) debug.enable('http')
+    if (options.debug && options.debugHeaders) debug.enable('http,http:headers')
     this.options = options
     const apiUrl = url.URL ? new url.URL(vars.apiUrl) : url.parse(vars.apiUrl)
     const envHeaders = JSON.parse(process.env.HEROKU_HEADERS || '{}')
@@ -111,6 +117,14 @@ export class APIClient {
         }
       }
 
+      static showWarnings<T>(response: HTTP<T>) {
+        const warnings = response.headers['x-heroku-warning'] || response.headers['warning-message']
+        if (Array.isArray(warnings))
+          warnings.forEach(warning => warn(warning))
+        else if (typeof warnings === 'string')
+          warn(warnings)
+      }
+
       static configDelinquency(url: string, opts: APIClient.Options): void {
         if (opts.method?.toUpperCase() !== 'GET' || (opts.hostname && opts.hostname !== apiUrl.hostname)) {
           delinquencyConfig.fetch_delinquency = false
@@ -153,7 +167,7 @@ export class APIClient {
           }
 
           if (deletion)
-            warn(`This ${resource} is delinquent with payment and we suspended it on ${new Date(suspension)}. If the ${resource} is still delinquent, we'll delete it on ${new Date(deletion)}.`)
+            warn(`This ${resource} is delinquent with payment and we suspended it on ${new Date(suspension)}. If the ${resource} is still delinquent, we‘ll delete it on ${new Date(deletion)}.`)
         } else if (deletion)
           warn(`This ${resource} is delinquent with payment and we‘ll delete it on ${new Date(deletion)}.`)
 
@@ -201,6 +215,7 @@ export class APIClient {
           this.notifyDelinquency(delinquencyInfo)
 
           this.trackRequestIds<T>(response)
+          this.showWarnings<T>(response)
           return response
         } catch (error) {
           if (!(error instanceof deps.HTTP.HTTPError)) throw error

--- a/src/command.ts
+++ b/src/command.ts
@@ -3,7 +3,7 @@ import {deprecate} from 'util'
 
 const pjson = require('../package.json')
 
-import {APIClient} from './api-client'
+import {APIClient, IOptions} from './api-client'
 import deps from './deps'
 
 const deprecatedCLI = deprecate(() => {
@@ -17,7 +17,11 @@ export abstract class Command extends Base {
 
   get heroku(): APIClient {
     if (this._heroku) return this._heroku
-    this._heroku = new deps.APIClient(this.config)
+    const options: IOptions = {
+      debug: process.env.HEROKU_DEBUG === '1' || process.env.HEROKU_DEBUG?.toUpperCase() === 'TRUE',
+      debugHeaders: process.env.HEROKU_DEBUG_HEADERS === '1' || process.env.HEROKU_DEBUG_HEADERS?.toUpperCase() === 'TRUE',
+    }
+    this._heroku = new deps.APIClient(this.config, options)
     return this._heroku
   }
 

--- a/test/api-client.test.ts
+++ b/test/api-client.test.ts
@@ -474,8 +474,8 @@ describe('api_client', () => {
 
           expect(cmd.heroku.options.debug).to.eq(true)
           expect(cmd.heroku.options.debugHeaders).to.eq(false)
-          expect(stderr.output).to.contain('http → GET https://api.heroku.com/apps')
-          expect(stderr.output).not.to.contain("http   accept: 'application/vnd.heroku+json; version=3")
+          expect(stderr.output).to.contain('GET https://api.heroku.com/apps')
+          expect(stderr.output).not.to.contain("accept: 'application/vnd.heroku+json; version=3")
         })
     })
 
@@ -498,8 +498,8 @@ describe('api_client', () => {
 
           expect(cmd.heroku.options.debug).to.eq(true)
           expect(cmd.heroku.options.debugHeaders).to.eq(true)
-          expect(stderr.output).to.contain('http → GET https://api.heroku.com/apps')
-          expect(stderr.output).to.contain("http   accept: 'application/vnd.heroku+json; version=3")
+          expect(stderr.output).to.contain('GET https://api.heroku.com/apps')
+          expect(stderr.output).to.contain("accept: 'application/vnd.heroku+json; version=3")
         })
     })
   })
@@ -523,8 +523,8 @@ describe('api_client', () => {
 
           expect(cmd.heroku.options.debug).to.eq(false)
           expect(cmd.heroku.options.debugHeaders).to.eq(true)
-          expect(stderr.output).not.to.contain('http → GET https://api.heroku.com/apps')
-          expect(stderr.output).not.to.contain("http   accept: 'application/vnd.heroku+json; version=3")
+          expect(stderr.output).not.to.contain('GET https://api.heroku.com/apps')
+          expect(stderr.output).not.to.contain("accept: 'application/vnd.heroku+json; version=3")
         })
     })
 
@@ -543,8 +543,8 @@ describe('api_client', () => {
 
           expect(cmd.heroku.options.debug).to.eq(false)
           expect(cmd.heroku.options.debugHeaders).to.eq(false)
-          expect(stderr.output).not.to.contain('http → GET https://api.heroku.com/apps')
-          expect(stderr.output).not.to.contain("http   accept: 'application/vnd.heroku+json; version=3")
+          expect(stderr.output).not.to.contain('GET https://api.heroku.com/apps')
+          expect(stderr.output).not.to.contain("accept: 'application/vnd.heroku+json; version=3")
         })
     })
   })


### PR DESCRIPTION
## Description

When we removed support for `heroku-cli-util` two shared behaviors implemented at the APIClient were lost:
- Showing warnings on `$stderr` when either `X-Heroku-Warning` or `Warning-Message` headers were set on the response.
- Showing debug information for HTTP request/responses and additionally their headers, when `HEROKU_DEBUG` and `HEROKU_DEBUG_HEADERS` were respectively set to `1` or `true`.

Here we reintroduce those behaviors in the code for the new APIClient implemented on `@heroku-cli/command`

## Test procedure

### Pre-work
- Fetch this branch.
- Run `yarn && yarn build && yarn link` on your local `heroku-cli-command` workspace.
- Then change to your local workspace for the Heroku `cli` repo.
- Run `yarn link -p <path-to-your-heroku-cli-command-workspace>`.
- Run `yarn && yarn build`.

### Actual testing

- Run ```HEROKU_DEBUG=1 ./bin/run apps```, you should see debug info for HTTP request/responses without headers.
- Run ```HEROKU_DEBUG=1 HEROKU_DEBUG_HEADERS=1 ./bin/run apps```, you should see HTTP debug info including headers.
- Run ```HEROKU_DEBUG_HEADERS=1 ./bin/run apps```, you shouldn't see any HTTP debug info, because `HEROKU_DEBUG=1` is required to enable debugging.
- Run ```heroku config:set HEROKU_TEST=dummy -a <test-app>``` on any test app you own, you shouldn't see any warnings.
- Run ```./bin/run config:set HEROKU_TEST=dummy -a <test-app>``` with includes the fix, you should see the warning `Warning: The "HEROKU_" namespace is protected and shouldn't be used.`

## SOC2 Compliance
[GUS Work Item](https://gus.lightning.force.com/a07EE00001xCaiHYAS)