### PR TITLE
Move yargs into dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "http-call": "^5.3.0",
     "netrc-parser": "^3.1.6",
     "open": "^8.4.2",
-    "uuid": "^8.3.0"
+    "uuid": "^8.3.0",
+    "yargs-parser": "^18.1.3",
+    "yargs-unparser": "^2.0.0"
   },
   "devDependencies": {
     "@heroku-cli/schema": "^1.0.25",
@@ -48,9 +50,7 @@
     "stdout-stderr": "^0.1.13",
     "ts-node": "^10.9.1",
     "tslint": "^6.1.3",
-    "typescript": "^4.8.4",
-    "yargs-parser": "^18.1.3",
-    "yargs-unparser": "^2.0.0"
+    "typescript": "^4.8.4"
   },
   "engines": {
     "node": ">= 16.20.0"

--- a/package.json
+++ b/package.json
@@ -48,10 +48,8 @@
     "stdout-stderr": "^0.1.13",
     "ts-node": "^10.9.1",
     "tslint": "^6.1.3",
-    "typescript": "^4.8.4"
-  },
-  "peerDependencies": {
-    "yargs-parser": ">=18.x",
+    "typescript": "^4.8.4",
+    "yargs-parser": "^18.1.3",
     "yargs-unparser": "^2.0.0"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1239,7 +1239,7 @@ camelcase-keys@^6.2.2:
     map-obj "^4.0.0"
     quick-lru "^4.0.1"
 
-camelcase@^5.3.1:
+camelcase@^5.0.0, camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
@@ -1618,7 +1618,7 @@ decamelize-keys@^1.1.0:
     decamelize "^1.1.0"
     map-obj "^1.0.0"
 
-decamelize@^1.1.0:
+decamelize@^1.1.0, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
   integrity sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==
@@ -5476,6 +5476,14 @@ yaml@^1.10.0:
   version "1.10.2"
   resolved "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
+
+yargs-parser@^18.1.3:
+  version "18.1.3"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
+  integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
 
 yargs-parser@^20.2.2, yargs-parser@^20.2.3, yargs-parser@^20.2.9:
   version "20.2.9"


### PR DESCRIPTION
We're seeing some issues with plugin installation and the CLI that seem to arise from not being able to find `yargs-parser`. This hopefully will address that.