### PR TITLE
fix(W-17812967): Heroku-cli-command: Header overflow

### DIFF
--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -174,16 +174,17 @@ export class APIClient {
         delinquencyConfig.warning_shown = true
       }
 
-      // eslint-disable-next-line complexity
       static async request<T>(url: string, opts: APIClient.Options = {}, retries = 3): Promise<APIHTTPClient<T>> {
         opts.headers = opts.headers || {}
         const currentRequestId = RequestId.create() && RequestId.headerValue
 
         // Accumulation of requestIds in the header
-        // causes a header overflow error. These have been
+        // causes a header overflow error. Headers have been
         // observed to be larger than 8k (Node default max)
         // in long running poll operations such as pg:wait
-        if (Buffer.from(currentRequestId).byteLength > 1024 * 8) {
+        // We limit the Request-Id header to 7k to allow some
+        // room fo other headers.
+        if (Buffer.from(currentRequestId).byteLength > 1024 * 7) {
           RequestId.empty()
           opts.headers[requestIdHeader] = RequestId.create()
         } else {


### PR DESCRIPTION
This PR fixes the accumulation of requestIds in the header causing a header overflow error in long running poll operations. These have been observed to be larger than 8k (Node default max) in commands such as pg:wait

This PR limits the `Request-Id` header size to 7k which allows 1k for other header data. If the 7k limit is exceeded, the `Request-Id` is stripped of all previous values and is started over.

Note that a side effect of this is that long running poll operations now have the potential of fracturing the API call 'story' in tracking data.

## test
1. build & pack (`npm run build && npm pack`)
2. install the packed tarball in the Heroku CLI project
3. comment out the `break` statement in packages/cli/src/commands/ps/wait.ts
4. run the command and let it go a while
5. OBSERVE - no header overflow is seen