### PR TITLE
feat: bump http-call to enable sso and token redactions

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/heroku/heroku-cli-command/issues",
   "dependencies": {
     "@heroku-cli/color": "^2.0.1",
-    "@heroku/http-call": "^5.4.0",
+    "@heroku/http-call": "^5.5.0",
     "@oclif/core": "^2.16.0",
     "cli-ux": "^6.0.9",
     "debug": "^4.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -269,15 +269,17 @@
   resolved "https://registry.npmjs.org/@heroku-cli/schema/-/schema-1.0.25.tgz"
   integrity sha512-7V6/WdTHrsvpqeqttm4zhzVJyt/Us/Cz9oS4yure4JdLtwlr2eF6PvlDLA5ZIvBybMtSDyxhHid0PeshKLtwxw==
 
-"@heroku/http-call@^5.4.0":
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/@heroku/http-call/-/http-call-5.4.0.tgz#1f3d804d17888c61d375d2dcb399f405781132e8"
-  integrity sha512-8ys8jFP9l1wFXNmhmUb/EKLY/3flGzd7lv3x5MCw+36ov+qR9OFgk7bNHn3s+FPUKRSf/2GmKJjJmgnaD1YMmA==
+"@heroku/http-call@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@heroku/http-call/-/http-call-5.5.0.tgz#46716bf03e0bec3b5bb65654c1fa1f90b5b74127"
+  integrity sha512-fHeprmOuBqrfUlRmSjUvuY7blagZ5GDtqWAdGqUeVNfiXdZBul7Q/O8wJMqvqwyR9GjU8gq0Hl1U+J5jThcOcA==
   dependencies:
+    chalk "^4.1.2"
     content-type "^1.0.5"
     debug "^4.4.0"
     is-retry-allowed "^2.2.0"
     is-stream "^2.0.0"
+    sinon "^20.0.0"
     tunnel-agent "^0.6.0"
 
 "@humanwhocodes/config-array@^0.5.0":
@@ -666,7 +668,14 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
-"@sinonjs/samsam@^8.0.0":
+"@sinonjs/fake-timers@^13.0.5":
+  version "13.0.5"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz#36b9dbc21ad5546486ea9173d6bea063eb1717d5"
+  integrity sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==
+  dependencies:
+    "@sinonjs/commons" "^3.0.1"
+
+"@sinonjs/samsam@^8.0.0", "@sinonjs/samsam@^8.0.1":
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-8.0.2.tgz#e4386bf668ff36c95949e55a38dc5f5892fc2689"
   integrity sha512-v46t/fwnhejRSFTGqbpn9u+LQ9xJDse10gNnPgAcxgdoCDMXj/G2asWAC/8Qs+BAZDicX+MNZouXT1A7c83kVw==
@@ -1803,6 +1812,11 @@ diff@^5.1.0, diff@^5.2.0:
   version "5.2.0"
   resolved "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz"
   integrity sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==
+
+diff@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-7.0.0.tgz#3fb34d387cd76d803f6eebea67b921dab0182a9a"
+  integrity sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -4670,6 +4684,17 @@ sinon@^16.1.3:
     "@sinonjs/samsam" "^8.0.0"
     diff "^5.1.0"
     nise "^5.1.4"
+    supports-color "^7.2.0"
+
+sinon@^20.0.0:
+  version "20.0.0"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-20.0.0.tgz#4b653468735f7152ba694d05498c2b5d024ab006"
+  integrity sha512-+FXOAbdnj94AQIxH0w1v8gzNxkawVvNqE3jUzRLptR71Oykeu2RrQXXl/VQjKay+Qnh73fDt/oDfMo6xMeDQbQ==
+  dependencies:
+    "@sinonjs/commons" "^3.0.1"
+    "@sinonjs/fake-timers" "^13.0.5"
+    "@sinonjs/samsam" "^8.0.1"
+    diff "^7.0.0"
     supports-color "^7.2.0"
 
 slash@^3.0.0:


### PR DESCRIPTION
[WI](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002EAIsvYAH/view)

Bumps the version of `http-call` in order to allow for redactions of the `x-addon-sso` header and anything that is returned from `/sso` endpoints. For more info see https://github.com/heroku/http-call/pull/68.