### PR TITLE
W-19264912 feat: add domain name validation for outgoing requests

### DIFF
--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -159,7 +159,7 @@ export class APIClient {
         }
 
         if (!Object.keys(opts.headers).some(h => h.toLowerCase() === 'authorization')) {
-          // Handle both relative and absolute URLs for security check
+          // Handle both relative and absolute URLs for validation
           let targetUrl: URL
           try {
             // Try absolute URL first

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -14,8 +14,8 @@ import {yubikey} from './yubikey.js'
 
 const netrc = new Netrc()
 
-export const ALLOWED_HEROKU_DOMAINS = Object.freeze(['heroku.com', 'herokai.com', 'herokuspace.com', 'herokudev.com']) as const
-export const LOCALHOST_DOMAINS = Object.freeze(['localhost', '127.0.0.1']) as const
+export const ALLOWED_HEROKU_DOMAINS = Object.freeze(['heroku.com', 'herokai.com', 'herokuspace.com', 'herokudev.com'])
+export const LOCALHOST_DOMAINS = Object.freeze(['localhost', '127.0.0.1'])
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace APIClient {

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -14,8 +14,8 @@ import {yubikey} from './yubikey.js'
 
 const netrc = new Netrc()
 
-export const ALLOWED_HEROKU_DOMAINS = ['heroku.com', 'herokai.com', 'herokuspace.com', 'herokudev.com'] as const
-export const LOCALHOST_DOMAINS = ['localhost', '127.0.0.1'] as const
+export const ALLOWED_HEROKU_DOMAINS = Object.freeze(['heroku.com', 'herokai.com', 'herokuspace.com', 'herokudev.com']) as const
+export const LOCALHOST_DOMAINS = Object.freeze(['localhost', '127.0.0.1']) as const
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace APIClient {

--- a/src/vars.ts
+++ b/src/vars.ts
@@ -1,3 +1,4 @@
+import {ux} from '@oclif/core'
 import * as url from 'node:url'
 
 import {ALLOWED_HEROKU_DOMAINS, LOCALHOST_DOMAINS} from './api-client.js'
@@ -46,7 +47,7 @@ export class Vars {
     const {envHost} = this
 
     if (envHost && !this.isValidHerokuHost(envHost)) {
-      console.warn(`Invalid HEROKU_HOST '${envHost}' - using default`)
+      ux.warn(`Invalid HEROKU_HOST '${envHost}' - using default`)
       return 'heroku.com'
     }
 

--- a/src/vars.ts
+++ b/src/vars.ts
@@ -1,5 +1,7 @@
 import * as url from 'node:url'
 
+import {ALLOWED_HEROKU_DOMAINS, LOCALHOST_DOMAINS} from './api-client.js'
+
 export class Vars {
   get apiHost(): string {
     if (this.host.startsWith('http')) {
@@ -41,7 +43,14 @@ export class Vars {
   }
 
   get host(): string {
-    return this.envHost || 'heroku.com'
+    const {envHost} = this
+
+    if (envHost && !this.isValidHerokuHost(envHost)) {
+      console.warn(`Invalid HEROKU_HOST '${envHost}' - using default`)
+      return 'heroku.com'
+    }
+
+    return envHost || 'heroku.com'
   }
 
   get httpGitHost(): string {
@@ -61,6 +70,13 @@ export class Vars {
     return process.env.HEROKU_CLOUD === 'staging'
       ? 'https://particleboard-staging-cloud.herokuapp.com'
       : 'https://particleboard.heroku.com'
+  }
+
+  private isValidHerokuHost(host: string): boolean {
+    // Remove protocol if present
+    const cleanHost = host.replace(/^https?:\/\//, '')
+
+    return ALLOWED_HEROKU_DOMAINS.some(domain => cleanHost.endsWith(`.${domain}`)) || LOCALHOST_DOMAINS.some(domain => cleanHost.endsWith(domain))
   }
 }
 

--- a/src/vars.ts
+++ b/src/vars.ts
@@ -76,7 +76,7 @@ export class Vars {
     // Remove protocol if present
     const cleanHost = host.replace(/^https?:\/\//, '')
 
-    return ALLOWED_HEROKU_DOMAINS.some(domain => cleanHost.endsWith(`.${domain}`)) || LOCALHOST_DOMAINS.some(domain => cleanHost.endsWith(domain))
+    return ALLOWED_HEROKU_DOMAINS.some(domain => cleanHost.endsWith(`.${domain}`)) || LOCALHOST_DOMAINS.some(domain => cleanHost.includes(domain))
   }
 }
 

--- a/test/api-client.test.ts
+++ b/test/api-client.test.ts
@@ -113,6 +113,16 @@ describe('api_client', () => {
 
   describe('with HEROKU_HOST', () => {
     test
+      .it('rejects invalid HEROKU_HOST and uses default API', async ctx => {
+        process.env.HEROKU_HOST = 'http://bogus-server.com'
+        api = nock('https://api.heroku.com') // Should fallback to default
+        api.get('/apps').reply(200, [{name: 'myapp'}])
+
+        const cmd = new Command([], ctx.config)
+        await cmd.heroku.get('/apps')
+      })
+
+    test
       .it('makes an HTTP request with HEROKU_HOST', async ctx => {
         const localHostURI = 'http://localhost:5000'
         process.env.HEROKU_HOST = localHostURI

--- a/test/vars.test.ts
+++ b/test/vars.test.ts
@@ -22,26 +22,44 @@ describe('vars', () => {
     expect(vars.particleboardUrl).to.equal('https://particleboard.heroku.com')
   })
 
-  it('respects HEROKU_HOST', () => {
-    process.env.HEROKU_HOST = 'customhost'
-    expect(vars.apiHost).to.equal('api.customhost')
-    expect(vars.apiUrl).to.equal('https://api.customhost')
-    expect(vars.gitHost).to.equal('customhost')
-    expect(vars.host).to.equal('customhost')
-    expect(vars.httpGitHost).to.equal('git.customhost')
-    expect(vars.gitPrefixes).to.deep.equal(['git@customhost:', 'ssh://git@customhost/', 'https://git.customhost/'])
+  it('respects valid HEROKU_HOST values', () => {
+    // Test with a valid heroku.com subdomain
+    process.env.HEROKU_HOST = 'staging.heroku.com'
+    expect(vars.apiHost).to.equal('api.staging.heroku.com')
+    expect(vars.apiUrl).to.equal('https://api.staging.heroku.com')
+    expect(vars.gitHost).to.equal('staging.heroku.com')
+    expect(vars.host).to.equal('staging.heroku.com')
+    expect(vars.httpGitHost).to.equal('git.staging.heroku.com')
+    expect(vars.gitPrefixes).to.deep.equal(['git@staging.heroku.com:', 'ssh://git@staging.heroku.com/', 'https://git.staging.heroku.com/'])
     expect(vars.particleboardUrl).to.equal('https://particleboard.heroku.com')
   })
 
-  it('respects HEROKU_HOST as url', () => {
-    process.env.HEROKU_HOST = 'https://customhost'
-    expect(vars.host).to.equal('https://customhost')
-    expect(vars.apiHost).to.equal('customhost')
-    expect(vars.apiUrl).to.equal('https://customhost')
-    expect(vars.gitHost).to.equal('customhost')
-    expect(vars.httpGitHost).to.equal('customhost')
-    expect(vars.gitPrefixes).to.deep.equal(['git@customhost:', 'ssh://git@customhost/', 'https://customhost/'])
+  it('rejects invalid HEROKU_HOST values for security', () => {
+    // Test that invalid hosts are rejected and fallback to default
+    process.env.HEROKU_HOST = 'bogus-server.com'
+    expect(vars.host).to.equal('heroku.com') // Should fallback to default
+    expect(vars.apiHost).to.equal('api.heroku.com')
+    expect(vars.apiUrl).to.equal('https://api.heroku.com')
+  })
+
+  it('respects legitimate HEROKU_HOST as url', () => {
+    // Test with a valid heroku.com subdomain URL
+    process.env.HEROKU_HOST = 'https://staging.heroku.com'
+    expect(vars.host).to.equal('https://staging.heroku.com')
+    expect(vars.apiHost).to.equal('staging.heroku.com')
+    expect(vars.apiUrl).to.equal('https://staging.heroku.com')
+    expect(vars.gitHost).to.equal('staging.heroku.com')
+    expect(vars.httpGitHost).to.equal('staging.heroku.com')
+    expect(vars.gitPrefixes).to.deep.equal(['git@staging.heroku.com:', 'ssh://git@staging.heroku.com/', 'https://staging.heroku.com/'])
     expect(vars.particleboardUrl).to.equal('https://particleboard.heroku.com')
+  })
+
+  it('rejects invalid HEROKU_HOST URLs', () => {
+    // Test that invalid URL hosts are rejected and fallback to default
+    process.env.HEROKU_HOST = 'https://bogus-server.com'
+    expect(vars.host).to.equal('heroku.com') // Should fallback to default for security
+    expect(vars.apiHost).to.equal('api.heroku.com')
+    expect(vars.apiUrl).to.equal('https://api.heroku.com')
   })
 
   it('respects HEROKU_PARTICLEBOARD_URL', () => {


### PR DESCRIPTION
[W-19264912](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002JfNJOYA3/view)

### Description

This PR adds domain validation for making outbound requests. Authentication will only happen for valid domains, and host resolution will only work for valid domains, otherwise defaulting to heroku.com

### Testing

1. Pull down this branch and `npm install && npm run build`
2. `HEROKU_HOST=bogus-domain.com npm run example whoami`