### PR TITLE
chore: update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,367 +1,429 @@
+## [12.0.2](https://github.com/heroku/heroku-cli-command/compare/v12.0.1...v12.0.2) (2025-08-07)
+
+### Bug Fixes
+
+* convert to esm ([#196](https://github.com/heroku/heroku-cli-command/issues/196)) ([33eaf26](https://github.com/heroku/heroku-cli-command/commit/33eaf26ca4725f9f8e1deeb5f078e342a06bfbe0))
+## [12.0.1](https://github.com/heroku/heroku-cli-command/compare/v11.3.0...v12.0.1) (2025-05-23)
+
+### ⚠ BREAKING CHANGES
+
+* upgrade to oclif/core v4 (#180)
+
+### Features
+
+* Upgrade to node 20, look for "request-id" when tracking requests ([#160](https://github.com/heroku/heroku-cli-command/issues/160)) ([58f0d49](https://github.com/heroku/heroku-cli-command/commit/58f0d49539f39e2e4e10202ea3f6421298242791))
+* upgrade to oclif/core v4 ([#180](https://github.com/heroku/heroku-cli-command/issues/180)) ([ca0667b](https://github.com/heroku/heroku-cli-command/commit/ca0667b0c4a773509d7a663fe545bae41459fb09))
+
+### Bug Fixes
+
+* update versions of @heroku/http-call and debug ([#156](https://github.com/heroku/heroku-cli-command/issues/156)) ([221239d](https://github.com/heroku/heroku-cli-command/commit/221239d7e7a2e3b45d3040cc96d1c7198cc135c2))
+* **W-17812967:** Heroku-cli-command: Header overflow ([#159](https://github.com/heroku/heroku-cli-command/issues/159)) ([5379d04](https://github.com/heroku/heroku-cli-command/commit/5379d0448f934090091c93703b56b75e7c00faa5))
+## [11.3.0](https://github.com/heroku/heroku-cli-command/compare/v11.2.2...v11.3.0) (2024-08-19)
+## [11.2.2](https://github.com/heroku/heroku-cli-command/compare/v11.2.0...v11.2.2) (2024-08-13)
+
+### Bug Fixes
+
+* **W-16338640:** Update backwards compatibility for CLI commands ([#138](https://github.com/heroku/heroku-cli-command/issues/138)) ([1204334](https://github.com/heroku/heroku-cli-command/commit/120433424a759dd7a5e90a4dd864454b97678c3e))
+* **W-16338640:** Update logic for backwards compatibility for CLI commands ([#139](https://github.com/heroku/heroku-cli-command/issues/139)) ([2c30939](https://github.com/heroku/heroku-cli-command/commit/2c30939207d6e44b4e296b97ab5bccb3f3890809))
+## [11.2.0](https://github.com/heroku/heroku-cli-command/compare/v11.1.2...v11.2.0) (2024-08-08)
+
+### Bug Fixes
+
+* **W-16338640:** Backward compatibility for CLI commands ([#137](https://github.com/heroku/heroku-cli-command/issues/137)) ([45632b3](https://github.com/heroku/heroku-cli-command/commit/45632b399af04c3c420e9cdb580bbf615d30d536))
+## [11.1.2](https://github.com/heroku/heroku-cli-command/compare/v11.1.1...v11.1.2) (2024-06-12)
+## [11.1.1](https://github.com/heroku/heroku-cli-command/compare/v11.1.0...v11.1.1) (2024-06-12)
+## [11.1.0](https://github.com/heroku/heroku-cli-command/compare/v11.0.0...v11.1.0) (2024-06-12)
+## [11.0.0](https://github.com/heroku/heroku-cli-command/compare/v10.0.0...v11.0.0) (2024-05-13)
+## [10.0.0](https://github.com/heroku/heroku-cli-command/compare/v9.0.2...v10.0.0) (2023-07-06)
+## [9.0.2](https://github.com/heroku/heroku-cli-command/compare/v9.0.1...v9.0.2) (2023-02-22)
+## [9.0.1](https://github.com/heroku/heroku-cli-command/compare/v9.0.0...v9.0.1) (2022-12-09)
+## [9.0.0](https://github.com/heroku/heroku-cli-command/compare/v8.5.0...v9.0.0) (2022-12-06)
+## [8.5.0](https://github.com/heroku/heroku-cli-command/compare/v8.4.1...v8.5.0) (2021-05-04)
+## [8.4.1](https://github.com/heroku/heroku-cli-command/compare/v8.4.0...v8.4.1) (2021-02-18)
+## [8.4.0](https://github.com/heroku/heroku-cli-command/compare/v8.3.2...v8.4.0) (2020-09-09)
+
+### Features
+
+* add request ID threading ([#78](https://github.com/heroku/heroku-cli-command/issues/78)) ([9c9d66e](https://github.com/heroku/heroku-cli-command/commit/9c9d66edf40f5385978c9a37a064c7c74d6f57e3))
+## [8.3.2](https://github.com/heroku/heroku-cli-command/compare/v8.3.1...v8.3.2) (2020-08-31)
+
+### Bug Fixes
+
+* default http call url options ([#74](https://github.com/heroku/heroku-cli-command/issues/74)) ([f1a5504](https://github.com/heroku/heroku-cli-command/commit/f1a5504fc5d0a693c0eac523edc2f557a10a46bc))
+* **login:** put url on a separate line to make it easier to click in supporting terminals ([#72](https://github.com/heroku/heroku-cli-command/issues/72)) ([72f7d50](https://github.com/heroku/heroku-cli-command/commit/72f7d50c6b52ae6e3303637cdf2d12eb9b624460))
 ## [8.3.1](https://github.com/heroku/heroku-cli-command/compare/v8.3.0...v8.3.1) (2020-08-14)
 
 ### Bug Fixes
 
-* show URL for legacy SSO flow ([b32d733](https://github.com/heroku/heroku-cli-command/commit/b32d733))
-
-## [8.3.0](https://github.com/heroku/heroku-cli-command/compare/v8.2.5...v8.3.0) (2020-02-03)
+* **login:** show URL for legacy SSO flow ([#71](https://github.com/heroku/heroku-cli-command/issues/71)) ([b32d733](https://github.com/heroku/heroku-cli-command/commit/b32d733bad9d581291dc0953937ab354d1a768cf))
+## [8.3.0](https://github.com/heroku/heroku-cli-command/compare/v8.2.15...v8.3.0) (2020-02-03)
 
 ### Features
 
-* Override error message for login device_trust_required ([f5ad3bd](https://github.com/heroku/heroku-cli-command/commit/f5ad3bd)
+* Override error message for login device_trust_required ([#68](https://github.com/heroku/heroku-cli-command/issues/68)) ([f5ad3bd](https://github.com/heroku/heroku-cli-command/commit/f5ad3bd61744bc34c4abcc3d21ccf98c4e994b9e))
+## [8.2.15](https://github.com/heroku/heroku-cli-command/compare/v8.2.14...v8.2.15) (2019-11-04)
+## [8.2.14](https://github.com/heroku/heroku-cli-command/compare/v8.2.13...v8.2.14) (2019-08-08)
+## [8.2.13](https://github.com/heroku/heroku-cli-command/compare/v8.2.12...v8.2.13) (2019-07-29)
+## [8.2.12](https://github.com/heroku/heroku-cli-command/compare/v8.2.11...v8.2.12) (2019-06-19)
 
+### Bug Fixes
+
+* prioritize flags above env variables for the team flag default value ([#61](https://github.com/heroku/heroku-cli-command/issues/61)) ([b5a7831](https://github.com/heroku/heroku-cli-command/commit/b5a783122dac7b262d976900f4329e978d95a7d1))
+## [8.2.11](https://github.com/heroku/heroku-cli-command/compare/v8.2.10...v8.2.11) (2019-04-25)
+## [8.2.10](https://github.com/heroku/heroku-cli-command/compare/v8.2.9...v8.2.10) (2019-03-14)
+
+### Bug Fixes
+
+* browser open message should be on stderr ([6e40377](https://github.com/heroku/heroku-cli-command/commit/6e403770ce3dd89b0939a96a0228a318e1b0e787))
+## [8.2.9](https://github.com/heroku/heroku-cli-command/compare/v8.2.8...v8.2.9) (2019-03-14)
+
+### Bug Fixes
+
+* remove ellipses after login url ([50bd689](https://github.com/heroku/heroku-cli-command/commit/50bd689b81548e25c2386e235cae0260244da6f5))
+## [8.2.8](https://github.com/heroku/heroku-cli-command/compare/v8.2.7...v8.2.8) (2019-03-05)
+
+### Bug Fixes
+
+* always show login url ([#60](https://github.com/heroku/heroku-cli-command/issues/60)) ([fdca50c](https://github.com/heroku/heroku-cli-command/commit/fdca50c7b58271f7708b8ebc8b3f8c0d388551c4))
+## [8.2.7](https://github.com/heroku/heroku-cli-command/compare/v8.2.6...v8.2.7) (2019-02-27)
+## [8.2.6](https://github.com/heroku/heroku-cli-command/compare/v8.2.5...v8.2.6) (2018-12-04)
+
+### Bug Fixes
+
+* remove warning ([a517594](https://github.com/heroku/heroku-cli-command/commit/a5175942663afe3a16cd3205e78336d356202b88))
 ## [8.2.5](https://github.com/heroku/heroku-cli-command/compare/v8.2.4...v8.2.5) (2018-12-03)
 
-
 ### Bug Fixes
 
-* sso login ([c19df48](https://github.com/heroku/heroku-cli-command/commit/c19df48))
-
+* sso login ([c19df48](https://github.com/heroku/heroku-cli-command/commit/c19df487a5c342880ea21e8ddb385b55e0dd719f))
 ## [8.2.4](https://github.com/heroku/heroku-cli-command/compare/v8.2.3...v8.2.4) (2018-12-03)
 
-
 ### Bug Fixes
 
-* use SSO when HEROKU_LEGACY_SSO is set ([ae031d9](https://github.com/heroku/heroku-cli-command/commit/ae031d9))
-
+* use SSO when HEROKU_LEGACY_SSO is set ([ae031d9](https://github.com/heroku/heroku-cli-command/commit/ae031d9807f865b0c0ca2dffbff4bee4142bb3eb))
 ## [8.2.3](https://github.com/heroku/heroku-cli-command/compare/v8.2.2...v8.2.3) (2018-11-26)
 
-
 ### Bug Fixes
 
-* always show warning ([b5a5db0](https://github.com/heroku/heroku-cli-command/commit/b5a5db0))
-
+* always show warning ([b5a5db0](https://github.com/heroku/heroku-cli-command/commit/b5a5db0615404292aa8bb6587e7a4c93d14a1e54))
 ## [8.2.2](https://github.com/heroku/heroku-cli-command/compare/v8.2.1...v8.2.2) (2018-11-15)
 
-
 ### Bug Fixes
 
-* timeout and warn if browser fails to render ([e15c0b6](https://github.com/heroku/heroku-cli-command/commit/e15c0b6))
-
+* timeout and warn if browser fails to render ([e15c0b6](https://github.com/heroku/heroku-cli-command/commit/e15c0b61551e31555ae73151ddfc49e39c56a885))
 ## [8.2.1](https://github.com/heroku/heroku-cli-command/compare/v8.2.0...v8.2.1) (2018-11-12)
 
+### Bug Fixes
+
+* enable login on stable ([e782654](https://github.com/heroku/heroku-cli-command/commit/e7826545a0a7a536dd45ee43fa5ceba78683c1d9))
+## [8.2.0](https://github.com/heroku/heroku-cli-command/compare/v8.1.29...v8.2.0) (2018-10-08)
 
 ### Bug Fixes
 
-* enable login on stable ([e782654](https://github.com/heroku/heroku-cli-command/commit/e782654))
-
+* use browser login in beta ([d2abba1](https://github.com/heroku/heroku-cli-command/commit/d2abba1b70500a83dc151611bcd96e272d14e576))
 ## [8.1.29](https://github.com/heroku/heroku-cli-command/compare/v8.1.28...v8.1.29) (2018-09-14)
 
-
 ### Bug Fixes
 
-* updated deps ([4eb89cf](https://github.com/heroku/heroku-cli-command/commit/4eb89cf))
-
-<a name="8.1.28"></a>
+* updated deps ([4eb89cf](https://github.com/heroku/heroku-cli-command/commit/4eb89cff2c8948bf8a87d875a131aa4e7d7dfbe9))
 ## [8.1.28](https://github.com/heroku/heroku-cli-command/compare/v8.1.27...v8.1.28) (2018-08-28)
 
-
 ### Bug Fixes
 
-* description of login token ([c8e7975](https://github.com/heroku/heroku-cli-command/commit/c8e7975))
-
-<a name="8.1.27"></a>
+* description of login token ([c8e7975](https://github.com/heroku/heroku-cli-command/commit/c8e79753977477c0544bb8133156c960256d958a))
 ## [8.1.27](https://github.com/heroku/heroku-cli-command/compare/v8.1.26...v8.1.27) (2018-08-28)
 
-
 ### Bug Fixes
 
-* **login:** retry browser auth up to 3 times on 5xx ([5f7b570](https://github.com/heroku/heroku-cli-command/commit/5f7b570))
-* add hostname to browser auth ([0dc9248](https://github.com/heroku/heroku-cli-command/commit/0dc9248))
-
-<a name="8.1.26"></a>
+* add hostname to browser auth ([0dc9248](https://github.com/heroku/heroku-cli-command/commit/0dc9248bf1399e15cc5d59b4762d056b77e6461e))
+* **login:** retry browser auth up to 3 times on 5xx ([5f7b570](https://github.com/heroku/heroku-cli-command/commit/5f7b5705c0c4e8fffd9ed6690069137c8f93b1cc))
 ## [8.1.26](https://github.com/heroku/heroku-cli-command/compare/v8.1.25...v8.1.26) (2018-06-18)
 
-
 ### Bug Fixes
 
-* updated deps ([74071f9](https://github.com/heroku/heroku-cli-command/commit/74071f9))
+* updated deps ([74071f9](https://github.com/heroku/heroku-cli-command/commit/74071f97f75e95e812c6b110022cb7e0ab736bb4))
 
-<a name="8.1.25"></a>
+### Reverts
+
+* Revert "remove completions (#41)" ([1c5ef0e](https://github.com/heroku/heroku-cli-command/commit/1c5ef0e3dfa9c02607dcdbe883a70a9fd1e97d94)), closes [#41](https://github.com/heroku/heroku-cli-command/issues/41)
 ## [8.1.25](https://github.com/heroku/heroku-cli-command/compare/v8.1.24...v8.1.25) (2018-06-18)
 
-
 ### Bug Fixes
 
-* only use browser login when available ([#44](https://github.com/heroku/heroku-cli-command/issues/44)) ([b178343](https://github.com/heroku/heroku-cli-command/commit/b178343))
-
-<a name="8.1.24"></a>
+* only use browser login when available ([#44](https://github.com/heroku/heroku-cli-command/issues/44)) ([b178343](https://github.com/heroku/heroku-cli-command/commit/b1783435d57d258e74eaf5db8bde4132e4911b70))
 ## [8.1.24](https://github.com/heroku/heroku-cli-command/compare/v8.1.23...v8.1.24) (2018-06-09)
 
-
 ### Bug Fixes
 
-* ensure error is defined ([22175e1](https://github.com/heroku/heroku-cli-command/commit/22175e1))
-
-<a name="8.1.23"></a>
+* ensure error is defined ([22175e1](https://github.com/heroku/heroku-cli-command/commit/22175e1a170f9993186e467558aa403eca234a3c))
 ## [8.1.23](https://github.com/heroku/heroku-cli-command/compare/v8.1.22...v8.1.23) (2018-06-01)
 
-
 ### Bug Fixes
 
-* allow specifying Authorization for header ([#42](https://github.com/heroku/heroku-cli-command/issues/42)) ([a522961](https://github.com/heroku/heroku-cli-command/commit/a522961))
-
-<a name="8.1.22"></a>
+* allow specifying Authorization for header ([#42](https://github.com/heroku/heroku-cli-command/issues/42)) ([a522961](https://github.com/heroku/heroku-cli-command/commit/a522961164731a3c7ca94a3dcfd2d0505f9fadeb))
 ## [8.1.22](https://github.com/heroku/heroku-cli-command/compare/v8.1.21...v8.1.22) (2018-05-31)
 
-
 ### Bug Fixes
 
-* typescript 2.9 ([29daebc](https://github.com/heroku/heroku-cli-command/commit/29daebc))
-
-<a name="8.1.21"></a>
+* typescript 2.9 ([29daebc](https://github.com/heroku/heroku-cli-command/commit/29daebc9f8d516076b38b021deb96b1aa4794863))
 ## [8.1.21](https://github.com/heroku/heroku-cli-command/compare/v8.1.20...v8.1.21) (2018-05-31)
 
-
 ### Bug Fixes
 
-* use settings file for login insted of netrc ([a8340b4](https://github.com/heroku/heroku-cli-command/commit/a8340b4))
-
-<a name="8.1.20"></a>
+* use settings file for login insted of netrc ([a8340b4](https://github.com/heroku/heroku-cli-command/commit/a8340b42b356ceb4e6267268b55ee6356a61ec4d))
 ## [8.1.20](https://github.com/heroku/heroku-cli-command/compare/v8.1.19...v8.1.20) (2018-05-25)
 
+### Bug Fixes
+
+* add generic types to requests ([4b7e5d9](https://github.com/heroku/heroku-cli-command/commit/4b7e5d9d3c0f0fb01acbf1b23836cf0543a544ae))
+## [8.1.19](https://github.com/heroku/heroku-cli-command/compare/v8.1.18...v8.1.19) (2018-05-24)
 
 ### Bug Fixes
 
-* add generic types to requests ([4b7e5d9](https://github.com/heroku/heroku-cli-command/commit/4b7e5d9))
-
-<a name="8.1.18"></a>
+* logout ([5da3071](https://github.com/heroku/heroku-cli-command/commit/5da30710975f6155ca72db8fede2636eb9800ae7))
 ## [8.1.18](https://github.com/heroku/heroku-cli-command/compare/v8.1.17...v8.1.18) (2018-05-21)
 
-
 ### Bug Fixes
 
-* consolidate completions ([#38](https://github.com/heroku/heroku-cli-command/issues/38)) ([da45bf8](https://github.com/heroku/heroku-cli-command/commit/da45bf8))
-
-<a name="8.1.17"></a>
+* consolidate completions ([#38](https://github.com/heroku/heroku-cli-command/issues/38)) ([da45bf8](https://github.com/heroku/heroku-cli-command/commit/da45bf8d17c3d4b8ee55604990bd625874d316aa))
 ## [8.1.17](https://github.com/heroku/heroku-cli-command/compare/v8.1.16...v8.1.17) (2018-05-15)
 
-
 ### Bug Fixes
 
-* use caret versions ([0f38127](https://github.com/heroku/heroku-cli-command/commit/0f38127))
-
-<a name="8.1.16"></a>
+* use caret versions ([0f38127](https://github.com/heroku/heroku-cli-command/commit/0f38127fdc6776dd40603fd9e3002365137a2085))
 ## [8.1.16](https://github.com/heroku/heroku-cli-command/compare/v8.1.15...v8.1.16) (2018-05-11)
 
-
 ### Bug Fixes
 
-* use CLIError for git error ([0915f57](https://github.com/heroku/heroku-cli-command/commit/0915f57))
-
-<a name="8.1.15"></a>
+* use CLIError for git error ([0915f57](https://github.com/heroku/heroku-cli-command/commit/0915f575475b8ad9f5bea0f706a43c2d426aebca))
 ## [8.1.15](https://github.com/heroku/heroku-cli-command/compare/v8.1.14...v8.1.15) (2018-05-10)
 
-
 ### Bug Fixes
 
-* return request ([d9ae506](https://github.com/heroku/heroku-cli-command/commit/d9ae506))
-
-<a name="8.1.14"></a>
+* return request ([d9ae506](https://github.com/heroku/heroku-cli-command/commit/d9ae5067495bf405040d65cbe48b74e945828589))
 ## [8.1.14](https://github.com/heroku/heroku-cli-command/compare/v8.1.13...v8.1.14) (2018-05-10)
 
-
 ### Bug Fixes
 
-* do login first to fix sso login with browser ([1785ded](https://github.com/heroku/heroku-cli-command/commit/1785ded))
-
-<a name="8.1.13"></a>
+* do login first to fix sso login with browser ([1785ded](https://github.com/heroku/heroku-cli-command/commit/1785deda84298b0dbd6df57fbefe12482bab7035))
 ## [8.1.13](https://github.com/heroku/heroku-cli-command/compare/v8.1.12...v8.1.13) (2018-05-10)
 
-
 ### Bug Fixes
 
-* add retryAuth option ([0c2634a](https://github.com/heroku/heroku-cli-command/commit/0c2634a))
-
-<a name="8.1.12"></a>
+* add retryAuth option ([0c2634a](https://github.com/heroku/heroku-cli-command/commit/0c2634a1d890d937247fdd0eb1d65ade08f3a737))
 ## [8.1.12](https://github.com/heroku/heroku-cli-command/compare/v8.1.11...v8.1.12) (2018-05-09)
 
-
 ### Bug Fixes
 
-* show url when HEROKU_TESTING_HEADLESS_LOGIN is set ([c3a3f01](https://github.com/heroku/heroku-cli-command/commit/c3a3f01))
-
-<a name="8.1.11"></a>
+* show url when HEROKU_TESTING_HEADLESS_LOGIN is set ([c3a3f01](https://github.com/heroku/heroku-cli-command/commit/c3a3f01951261fdf892455e4b3204d3fc8a71e69))
 ## [8.1.11](https://github.com/heroku/heroku-cli-command/compare/v8.1.10...v8.1.11) (2018-05-09)
 
-
 ### Bug Fixes
 
-* show error when opn fails ([6c9fead](https://github.com/heroku/heroku-cli-command/commit/6c9fead))
-
-<a name="8.1.10"></a>
+* show error when opn fails ([6c9fead](https://github.com/heroku/heroku-cli-command/commit/6c9feade2435b1dd1baa01c4ec29fdbf057f1a43))
 ## [8.1.10](https://github.com/heroku/heroku-cli-command/compare/v8.1.9...v8.1.10) (2018-05-08)
 
-
 ### Bug Fixes
 
-* throw plain errors ([a6a821a](https://github.com/heroku/heroku-cli-command/commit/a6a821a))
-
-<a name="8.1.9"></a>
+* throw plain errors ([a6a821a](https://github.com/heroku/heroku-cli-command/commit/a6a821ab50f17aee0d8be0edb973f16b42abedeb))
 ## [8.1.9](https://github.com/heroku/heroku-cli-command/compare/v8.1.8...v8.1.9) (2018-05-08)
 
-
 ### Bug Fixes
 
-* sso logout ([102028a](https://github.com/heroku/heroku-cli-command/commit/102028a))
-
-<a name="8.1.8"></a>
+* sso logout ([102028a](https://github.com/heroku/heroku-cli-command/commit/102028a9cf18327bcc9061227dce7e0490e581d6))
 ## [8.1.8](https://github.com/heroku/heroku-cli-command/compare/v8.1.7...v8.1.8) (2018-05-08)
 
-
 ### Bug Fixes
 
-* sso login ([747ce09](https://github.com/heroku/heroku-cli-command/commit/747ce09))
-
-<a name="8.1.7"></a>
+* sso login ([747ce09](https://github.com/heroku/heroku-cli-command/commit/747ce09d838dcdbabb26775fcf79b6a7798fc2a7))
 ## [8.1.7](https://github.com/heroku/heroku-cli-command/compare/v8.1.6...v8.1.7) (2018-05-08)
 
-
 ### Bug Fixes
 
-* prettify errors ([6192ae5](https://github.com/heroku/heroku-cli-command/commit/6192ae5))
-
-<a name="8.1.6"></a>
+* prettify errors ([6192ae5](https://github.com/heroku/heroku-cli-command/commit/6192ae562b65e71be2886577000d44ce44b08e54))
 ## [8.1.6](https://github.com/heroku/heroku-cli-command/compare/v8.1.5...v8.1.6) (2018-05-08)
 
-
 ### Bug Fixes
 
-* add timeout ([6527877](https://github.com/heroku/heroku-cli-command/commit/6527877))
-* unref() login timeout ([c7ea0ab](https://github.com/heroku/heroku-cli-command/commit/c7ea0ab))
-
-<a name="8.1.5"></a>
+* add timeout ([6527877](https://github.com/heroku/heroku-cli-command/commit/65278773eae404bc0bd6e8ff776dfa304ba3c957))
+* unref() login timeout ([c7ea0ab](https://github.com/heroku/heroku-cli-command/commit/c7ea0ab0b8ea5c57211ac894dfd87a3afdbf3694))
 ## [8.1.5](https://github.com/heroku/heroku-cli-command/compare/v8.1.4...v8.1.5) (2018-05-08)
 
-
 ### Bug Fixes
 
-* do not error out if cannot logout ([8978ad4](https://github.com/heroku/heroku-cli-command/commit/8978ad4))
-
-<a name="8.1.4"></a>
+* do not error out if cannot logout ([8978ad4](https://github.com/heroku/heroku-cli-command/commit/8978ad473a47f5f16a8a59dcef05efc0011a7373))
 ## [8.1.4](https://github.com/heroku/heroku-cli-command/compare/v8.1.3...v8.1.4) (2018-05-08)
 
-
 ### Bug Fixes
 
-* make raw requests for http calls ([8629056](https://github.com/heroku/heroku-cli-command/commit/8629056))
-
-<a name="8.1.3"></a>
+* make raw requests for http calls ([8629056](https://github.com/heroku/heroku-cli-command/commit/8629056985eb43359a979798a1834dacb4cdff49))
 ## [8.1.3](https://github.com/heroku/heroku-cli-command/compare/v8.1.2...v8.1.3) (2018-05-07)
 
-
 ### Bug Fixes
 
-* use jwt auth on browser login ([3ba6ac7](https://github.com/heroku/heroku-cli-command/commit/3ba6ac7))
-* web -> browser ([2a78cc0](https://github.com/heroku/heroku-cli-command/commit/2a78cc0))
-
-<a name="8.1.2"></a>
+* use jwt auth on browser login ([3ba6ac7](https://github.com/heroku/heroku-cli-command/commit/3ba6ac7b54adfef487756d68cb0dbea9250abd72))
+* web -> browser ([2a78cc0](https://github.com/heroku/heroku-cli-command/commit/2a78cc07fdb3e93b3096ee45369ae9def38624fe))
 ## [8.1.2](https://github.com/heroku/heroku-cli-command/compare/v8.1.1...v8.1.2) (2018-05-06)
 
-
 ### Bug Fixes
 
-* error out on login when HEROKU_API_KEY is set ([eaad07f](https://github.com/heroku/heroku-cli-command/commit/eaad07f))
-
-<a name="8.1.1"></a>
+* error out on login when HEROKU_API_KEY is set ([eaad07f](https://github.com/heroku/heroku-cli-command/commit/eaad07fc18310d5a20a2e5003f57ded64eed39a2))
 ## [8.1.1](https://github.com/heroku/heroku-cli-command/compare/v8.1.0...v8.1.1) (2018-05-06)
 
-
 ### Bug Fixes
 
-* added stubbed browser property ([09b54ad](https://github.com/heroku/heroku-cli-command/commit/09b54ad))
-
-<a name="8.1.0"></a>
-# [8.1.0](https://github.com/heroku/heroku-cli-command/compare/v8.0.7...v8.1.0) (2018-05-06)
-
+* added stubbed browser property ([09b54ad](https://github.com/heroku/heroku-cli-command/commit/09b54ad35d57ebbcde2f5a8a89582f0de096dca4))
+## [8.1.0](https://github.com/heroku/heroku-cli-command/compare/v8.0.7...v8.1.0) (2018-05-06)
 
 ### Features
 
-* added login/logout ([#33](https://github.com/heroku/heroku-cli-command/issues/33)) ([c772322](https://github.com/heroku/heroku-cli-command/commit/c772322))
-
-<a name="8.0.7"></a>
+* added login/logout ([#33](https://github.com/heroku/heroku-cli-command/issues/33)) ([c772322](https://github.com/heroku/heroku-cli-command/commit/c772322981a49226d4a37f2a6769aeb07baf1ade))
 ## [8.0.7](https://github.com/heroku/heroku-cli-command/compare/v8.0.6...v8.0.7) (2018-05-02)
 
-
 ### Bug Fixes
 
-* skip rewriting auth header ([#32](https://github.com/heroku/heroku-cli-command/issues/32)) ([f74245f](https://github.com/heroku/heroku-cli-command/commit/f74245f))
-
-<a name="8.0.6"></a>
+* skip rewriting auth header ([#32](https://github.com/heroku/heroku-cli-command/issues/32)) ([f74245f](https://github.com/heroku/heroku-cli-command/commit/f74245fcc09539a8d714867053bb7cf2191271f8))
 ## [8.0.6](https://github.com/heroku/heroku-cli-command/compare/v8.0.5...v8.0.6) (2018-05-01)
 
-
 ### Bug Fixes
 
-* updated deps ([e8d6a78](https://github.com/heroku/heroku-cli-command/commit/e8d6a78))
-
-<a name="8.0.5"></a>
+* updated deps ([e8d6a78](https://github.com/heroku/heroku-cli-command/commit/e8d6a785f46abd62b045ac06a74b5b38ae5debe9))
 ## [8.0.5](https://github.com/heroku/heroku-cli-command/compare/v8.0.4...v8.0.5) (2018-04-17)
 
-
 ### Bug Fixes
 
-* updated deps ([56ed61b](https://github.com/heroku/heroku-cli-command/commit/56ed61b))
-
-<a name="8.0.4"></a>
+* updated deps ([56ed61b](https://github.com/heroku/heroku-cli-command/commit/56ed61bd5df63c0c853b543a509cbfd038b3cb39))
 ## [8.0.4](https://github.com/heroku/heroku-cli-command/compare/v8.0.3...v8.0.4) (2018-04-06)
 
-
 ### Bug Fixes
 
-* inherit errors from CLIError ([b590cd0](https://github.com/heroku/heroku-cli-command/commit/b590cd0))
-
-<a name="8.0.3"></a>
+* inherit errors from CLIError ([b590cd0](https://github.com/heroku/heroku-cli-command/commit/b590cd050ff8e2db177874006997ae65a240bc98))
 ## [8.0.3](https://github.com/heroku/heroku-cli-command/compare/v8.0.2...v8.0.3) (2018-04-06)
 
-
 ### Bug Fixes
 
-* HEROKU_API_KEY ([7c7d31b](https://github.com/heroku/heroku-cli-command/commit/7c7d31b))
-
-<a name="8.0.2"></a>
+* HEROKU_API_KEY ([7c7d31b](https://github.com/heroku/heroku-cli-command/commit/7c7d31b0121bf051a6cfaeffe4f5cd1f319f2884))
 ## [8.0.2](https://github.com/heroku/heroku-cli-command/compare/v8.0.1...v8.0.2) (2018-04-06)
 
-
 ### Bug Fixes
 
-* memoize auth token ([145f81e](https://github.com/heroku/heroku-cli-command/commit/145f81e))
+* memoize auth token ([145f81e](https://github.com/heroku/heroku-cli-command/commit/145f81eba1f238625d966e08deceb19f2ab1230d))
+## [8.0.1](https://github.com/heroku/heroku-cli-command/compare/v8.0.0...v8.0.1) (2018-04-06)
+## [8.0.0](https://github.com/heroku/heroku-cli-command/compare/v7.1.1...v8.0.0) (2018-04-06)
 
-<a name="8.0.0"></a>
-# [8.0.0](https://github.com/heroku/heroku-cli-command/compare/v7.1.1...v8.0.0) (2018-04-06)
-
-
-### Features
-
-* oclif ([ee07cb1](https://github.com/heroku/heroku-cli-command/commit/ee07cb1))
-
-
-### BREAKING CHANGES
+### ⚠ BREAKING CHANGES
 
 * this is the oclif version
 
-<a name="7.1.1"></a>
+### Features
+
+* oclif ([ee07cb1](https://github.com/heroku/heroku-cli-command/commit/ee07cb135c51904e30586f574bad5193de1c0596))
 ## [7.1.1](https://github.com/heroku/heroku-cli-command/compare/v7.1.0...v7.1.1) (2018-04-06)
 
+### Bug Fixes
+
+* updated metadata ([960d294](https://github.com/heroku/heroku-cli-command/commit/960d2942be969c2e29f4c9ae862ee3cdadb81a77))
+## [7.1.0](https://github.com/heroku/heroku-cli-command/compare/v7.0.16...v7.1.0) (2018-04-06)
 
 ### Bug Fixes
 
-* updated metadata ([960d294](https://github.com/heroku/heroku-cli-command/commit/960d294))
-
-<a name="7.1.0"></a>
-# [7.1.0](https://github.com/heroku/heroku-cli-command/compare/v7.0.16...v7.1.0) (2018-04-06)
-
-
-### Bug Fixes
-
-* fixed repo link ([9849b51](https://github.com/heroku/heroku-cli-command/commit/9849b51))
-* fixed tests ([525b0a7](https://github.com/heroku/heroku-cli-command/commit/525b0a7))
-* oclif rename ([7fc9586](https://github.com/heroku/heroku-cli-command/commit/7fc9586))
-* oclif rename ([f3bc43d](https://github.com/heroku/heroku-cli-command/commit/f3bc43d))
-* ran oclif generator ([714d15e](https://github.com/heroku/heroku-cli-command/commit/714d15e))
-* updated netrc-parser ([df72fd7](https://github.com/heroku/heroku-cli-command/commit/df72fd7))
-
+* fixed repo link ([9849b51](https://github.com/heroku/heroku-cli-command/commit/9849b511e141acb946fb597d47e4c7d7314cf0bc))
+* fixed tests ([525b0a7](https://github.com/heroku/heroku-cli-command/commit/525b0a7325fac3a94919c80966e380c0a28713e6))
+* ran oclif generator ([714d15e](https://github.com/heroku/heroku-cli-command/commit/714d15eeba873e1a3fdcc8c1d9341655c6972cab))
+* updated netrc-parser ([df72fd7](https://github.com/heroku/heroku-cli-command/commit/df72fd702fec2e2d499324f271969faf1d42edac))
+## [8.0.0-oclif.2](https://github.com/heroku/heroku-cli-command/compare/v7.0.15...v8.0.0-oclif.2) (2018-02-13)
 
 ### Features
 
-* anycli conversion ([201f534](https://github.com/heroku/heroku-cli-command/commit/201f534))
+* anycli conversion ([201f534](https://github.com/heroku/heroku-cli-command/commit/201f534bbbca0468e3425754beb34dca5b2c6567))
+
+### Bug Fixes
+
+* oclif rename ([7fc9586](https://github.com/heroku/heroku-cli-command/commit/7fc958629abd3ae33014eaaee9b2b1ebdb49db80))
+* oclif rename ([f3bc43d](https://github.com/heroku/heroku-cli-command/commit/f3bc43dd2112794090046dfafd82635e8910af15))
+## [7.0.16](https://github.com/heroku/heroku-cli-command/compare/v8.0.0-oclif.2...v7.0.16) (2018-03-19)
+## [8.0.0-oclif.2](https://github.com/heroku/heroku-cli-command/compare/v7.0.15...v8.0.0-oclif.2) (2018-02-13)
+
+### Features
+
+* anycli conversion ([201f534](https://github.com/heroku/heroku-cli-command/commit/201f534bbbca0468e3425754beb34dca5b2c6567))
+
+### Bug Fixes
+
+* oclif rename ([7fc9586](https://github.com/heroku/heroku-cli-command/commit/7fc958629abd3ae33014eaaee9b2b1ebdb49db80))
+* oclif rename ([f3bc43d](https://github.com/heroku/heroku-cli-command/commit/f3bc43dd2112794090046dfafd82635e8910af15))
+## [7.0.15](https://github.com/heroku/heroku-cli-command/compare/v7.0.14...v7.0.15) (2018-01-22)
+## [7.0.14](https://github.com/heroku/heroku-cli-command/compare/v7.0.13...v7.0.14) (2018-01-16)
+
+### Bug Fixes
+
+* added base ([933441d](https://github.com/heroku/heroku-cli-command/commit/933441df2fe8f39adf872a043f535d860f045d24))
+## [7.0.13](https://github.com/heroku/heroku-cli-command/compare/v7.0.12...v7.0.13) (2018-01-07)
+## [7.0.12](https://github.com/heroku/heroku-cli-command/compare/v7.0.11...v7.0.12) (2018-01-05)
+## [7.0.11](https://github.com/heroku/heroku-cli-command/compare/v7.0.10...v7.0.11) (2017-12-31)
+## [7.0.10](https://github.com/heroku/heroku-cli-command/compare/v7.0.0-beta.3...v7.0.10) (2017-12-27)
+## [7.0.0-beta.3](https://github.com/heroku/heroku-cli-command/compare/v7.0.0-beta.2...v7.0.0-beta.3) (2017-12-26)
+## [7.0.0-beta.2](https://github.com/heroku/heroku-cli-command/compare/v7.0.0-beta.1...v7.0.0-beta.2) (2017-12-26)
+## [7.0.0-beta.1](https://github.com/heroku/heroku-cli-command/compare/v7.0.9...v7.0.0-beta.1) (2017-12-26)
+## [7.0.9](https://github.com/heroku/heroku-cli-command/compare/v7.0.8...v7.0.9) (2017-12-26)
+## [7.0.8](https://github.com/heroku/heroku-cli-command/compare/v7.0.7...v7.0.8) (2017-12-26)
+## [7.0.7](https://github.com/heroku/heroku-cli-command/compare/v7.0.6...v7.0.7) (2017-12-26)
+## [7.0.6](https://github.com/heroku/heroku-cli-command/compare/v7.0.5...v7.0.6) (2017-12-25)
+## [7.0.5](https://github.com/heroku/heroku-cli-command/compare/v7.0.4...v7.0.5) (2017-12-22)
+## [7.0.4](https://github.com/heroku/heroku-cli-command/compare/v7.0.3...v7.0.4) (2017-12-20)
+## [7.0.3](https://github.com/heroku/heroku-cli-command/compare/v7.0.2...v7.0.3) (2017-12-20)
+## [7.0.2](https://github.com/heroku/heroku-cli-command/compare/v7.0.1...v7.0.2) (2017-12-20)
+## [7.0.1](https://github.com/heroku/heroku-cli-command/compare/v7.0.0...v7.0.1) (2017-12-20)
+## [7.0.0](https://github.com/heroku/heroku-cli-command/compare/v6.1.0-ts.1...v7.0.0) (2017-12-20)
+## [6.1.0-ts.1](https://github.com/heroku/heroku-cli-command/compare/v6.1.0-ts.0...v6.1.0-ts.1) (2017-12-18)
+## [6.1.0-ts.0](https://github.com/heroku/heroku-cli-command/compare/v6.0.1...v6.1.0-ts.0) (2017-12-15)
+## [6.0.1](https://github.com/heroku/heroku-cli-command/compare/v6.0.0...v6.0.1) (2017-12-13)
+## [6.0.0](https://github.com/heroku/heroku-cli-command/compare/v6.0.0-ts.1...v6.0.0) (2017-12-13)
+## [6.0.0-ts.1](https://github.com/heroku/heroku-cli-command/compare/v6.0.0-ts.0...v6.0.0-ts.1) (2017-12-13)
+## [6.0.0-ts.0](https://github.com/heroku/heroku-cli-command/compare/v5.0.3...v6.0.0-ts.0) (2017-12-13)
+## [5.0.3](https://github.com/heroku/heroku-cli-command/compare/v5.0.2...v5.0.3) (2017-11-27)
+## [5.0.2](https://github.com/heroku/heroku-cli-command/compare/v5.0.1...v5.0.2) (2017-11-27)
+## [5.0.1](https://github.com/heroku/heroku-cli-command/compare/v5.0.0...v5.0.1) (2017-11-27)
+## [5.0.0](https://github.com/heroku/heroku-cli-command/compare/v4.1.1...v5.0.0) (2017-09-28)
+## [4.1.1](https://github.com/heroku/heroku-cli-command/compare/v4.1.0...v4.1.1) (2017-09-27)
+## [4.1.0](https://github.com/heroku/heroku-cli-command/compare/v4.0.1...v4.1.0) (2017-09-12)
+## [4.0.1](https://github.com/heroku/heroku-cli-command/compare/v4.0.0...v4.0.1) (2017-09-09)
+## [4.0.0](https://github.com/heroku/heroku-cli-command/compare/v3.1.1...v4.0.0) (2017-09-09)
+## [3.1.1](https://github.com/heroku/heroku-cli-command/compare/v3.1.0...v3.1.1) (2017-09-08)
+## [3.1.0](https://github.com/heroku/heroku-cli-command/compare/v3.0.5...v3.1.0) (2017-09-08)
+## [3.0.5](https://github.com/heroku/heroku-cli-command/compare/v3.0.4...v3.0.5) (2017-09-08)
+## [3.0.4](https://github.com/heroku/heroku-cli-command/compare/v3.0.3...v3.0.4) (2017-09-08)
+
+### Reverts
+
+* Revert "updated deps" ([a68d73d](https://github.com/heroku/heroku-cli-command/commit/a68d73d214cf1f5c43c7727495e16a753ffa6113))
+## [3.0.3](https://github.com/heroku/heroku-cli-command/compare/v3.0.2...v3.0.3) (2017-09-07)
+## [3.0.2](https://github.com/heroku/heroku-cli-command/compare/v3.0.1...v3.0.2) (2017-09-06)
+## [3.0.1](https://github.com/heroku/heroku-cli-command/compare/v3.0.0...v3.0.1) (2017-09-06)
+## [3.0.0](https://github.com/heroku/heroku-cli-command/compare/v2.0.0...v3.0.0) (2017-09-05)
+## [2.0.0](https://github.com/heroku/heroku-cli-command/compare/v1.1.12...v2.0.0) (2017-09-02)
+## [1.1.12](https://github.com/heroku/heroku-cli-command/compare/v1.1.11...v1.1.12) (2017-09-01)
+## [1.1.11](https://github.com/heroku/heroku-cli-command/compare/v1.1.10...v1.1.11) (2017-08-31)
+## [1.1.10](https://github.com/heroku/heroku-cli-command/compare/v1.1.9...v1.1.10) (2017-08-29)
+## [1.1.9](https://github.com/heroku/heroku-cli-command/compare/v1.1.8...v1.1.9) (2017-08-29)
+## [1.1.8](https://github.com/heroku/heroku-cli-command/compare/v1.1.7...v1.1.8) (2017-08-29)
+## [1.1.7](https://github.com/heroku/heroku-cli-command/compare/v1.1.6...v1.1.7) (2017-08-11)
+## [1.1.6](https://github.com/heroku/heroku-cli-command/compare/v1.1.5...v1.1.6) (2017-08-07)
+## [1.1.5](https://github.com/heroku/heroku-cli-command/compare/v1.1.4...v1.1.5) (2017-07-21)
+## [1.1.4](https://github.com/heroku/heroku-cli-command/compare/v1.1.3...v1.1.4) (2017-07-10)
+## [1.1.3](https://github.com/heroku/heroku-cli-command/compare/v1.1.2...v1.1.3) (2017-07-07)
+## [1.1.2](https://github.com/heroku/heroku-cli-command/compare/v1.1.1...v1.1.2) (2017-06-28)
+## [1.1.1](https://github.com/heroku/heroku-cli-command/compare/v1.1.0...v1.1.1) (2017-06-20)
+## [1.1.0](https://github.com/heroku/heroku-cli-command/compare/v1.0.1...v1.1.0) (2017-06-08)
+## [1.0.1](https://github.com/heroku/heroku-cli-command/compare/v1.0.0...v1.0.1) (2017-06-07)
+## [1.0.0](https://github.com/heroku/heroku-cli-command/compare/v0.3.7...v1.0.0) (2017-06-07)
+## [0.3.7](https://github.com/heroku/heroku-cli-command/compare/v0.3.6...v0.3.7) (2017-06-02)
+## [0.3.6](https://github.com/heroku/heroku-cli-command/compare/v0.3.5...v0.3.6) (2017-06-02)
+## [0.3.5](https://github.com/heroku/heroku-cli-command/compare/v0.3.4...v0.3.5) (2017-06-02)
+## [0.3.4](https://github.com/heroku/heroku-cli-command/compare/v0.3.3...v0.3.4) (2017-06-01)
+## [0.3.3](https://github.com/heroku/heroku-cli-command/compare/v0.3.2...v0.3.3) (2017-06-01)
+## [0.3.2](https://github.com/heroku/heroku-cli-command/compare/v0.3.1...v0.3.2) (2017-05-31)
+## [0.3.1](https://github.com/heroku/heroku-cli-command/compare/v0.3.0...v0.3.1) (2017-05-24)
+## [0.3.0](https://github.com/heroku/heroku-cli-command/compare/v0.2.0...v0.3.0) (2017-05-19)
+## [0.2.0](https://github.com/heroku/heroku-cli-command/compare/v0.1.0...v0.2.0) (2017-05-19)
+## 0.1.0 (2017-05-18)


### PR DESCRIPTION
this updates the changelog to a format consistent with the `conventional-changelog` package now used. it also adds many missing entries.