### PR TITLE
feat: add domain name validation for outgoing requests

### DIFF
--- a/src/vars.ts
+++ b/src/vars.ts
@@ -1,8 +1,18 @@
+import {ux} from '@oclif/core'
 import * as url from 'url'
+
+import {ALLOWED_HEROKU_DOMAINS, LOCALHOST_DOMAINS} from './api-client'
 
 export class Vars {
   get host(): string {
-    return this.envHost || 'heroku.com'
+    const {envHost} = this
+
+    if (envHost && !this.isValidHerokuHost(envHost)) {
+      ux.warn(`Invalid HEROKU_HOST '${envHost}' - using default`)
+      return 'heroku.com'
+    }
+
+    return envHost || 'heroku.com'
   }
 
   get apiUrl(): string {
@@ -61,6 +71,13 @@ export class Vars {
     return process.env.HEROKU_CLOUD === 'staging' ?
       'https://particleboard-staging-cloud.herokuapp.com' :
       'https://particleboard.heroku.com'
+  }
+
+  private isValidHerokuHost(host: string): boolean {
+    // Remove protocol if present
+    const cleanHost = host.replace(/^https?:\/\//, '')
+
+    return ALLOWED_HEROKU_DOMAINS.some(domain => cleanHost.endsWith(`.${domain}`)) || LOCALHOST_DOMAINS.some(domain => cleanHost.includes(domain))
   }
 }
 

--- a/test/api-client.test.ts
+++ b/test/api-client.test.ts
@@ -98,6 +98,16 @@ describe('api_client', () => {
 
   describe('with HEROKU_HOST', () => {
     test
+      .it('rejects invalid HEROKU_HOST and uses default API', async ctx => {
+        process.env.HEROKU_HOST = 'http://bogus-server.com'
+        api = nock('https://api.heroku.com') // Should fallback to default
+        api.get('/apps').reply(200, [{name: 'myapp'}])
+
+        const cmd = new Command([], ctx.config)
+        await cmd.heroku.get('/apps')
+      })
+
+    test
       .it('makes an HTTP request with HEROKU_HOST', async ctx => {
         const localHostURI = 'http://localhost:5000'
         process.env.HEROKU_HOST = localHostURI

--- a/test/vars.test.ts
+++ b/test/vars.test.ts
@@ -28,26 +28,44 @@ describe('vars', () => {
     expect(vars.particleboardUrl).to.equal('https://particleboard.heroku.com')
   })
 
-  it('respects HEROKU_HOST', () => {
-    process.env.HEROKU_HOST = 'customhost'
-    expect(vars.apiHost).to.equal('api.customhost')
-    expect(vars.apiUrl).to.equal('https://api.customhost')
-    expect(vars.gitHost).to.equal('customhost')
-    expect(vars.host).to.equal('customhost')
-    expect(vars.httpGitHost).to.equal('git.customhost')
-    expect(vars.gitPrefixes).to.deep.equal(['git@customhost:', 'ssh://git@customhost/', 'https://git.customhost/'])
+  it('respects valid HEROKU_HOST values', () => {
+    // Test with a valid heroku.com subdomain
+    process.env.HEROKU_HOST = 'staging.heroku.com'
+    expect(vars.apiHost).to.equal('api.staging.heroku.com')
+    expect(vars.apiUrl).to.equal('https://api.staging.heroku.com')
+    expect(vars.gitHost).to.equal('staging.heroku.com')
+    expect(vars.host).to.equal('staging.heroku.com')
+    expect(vars.httpGitHost).to.equal('git.staging.heroku.com')
+    expect(vars.gitPrefixes).to.deep.equal(['git@staging.heroku.com:', 'ssh://git@staging.heroku.com/', 'https://git.staging.heroku.com/'])
     expect(vars.particleboardUrl).to.equal('https://particleboard.heroku.com')
   })
 
-  it('respects HEROKU_HOST as url', () => {
-    process.env.HEROKU_HOST = 'https://customhost'
-    expect(vars.host).to.equal('https://customhost')
-    expect(vars.apiHost).to.equal('customhost')
-    expect(vars.apiUrl).to.equal('https://customhost')
-    expect(vars.gitHost).to.equal('customhost')
-    expect(vars.httpGitHost).to.equal('customhost')
-    expect(vars.gitPrefixes).to.deep.equal(['git@customhost:', 'ssh://git@customhost/', 'https://customhost/'])
+  it('rejects invalid HEROKU_HOST values for security', () => {
+    // Test that invalid hosts are rejected and fallback to default
+    process.env.HEROKU_HOST = 'bogus-server.com'
+    expect(vars.host).to.equal('heroku.com') // Should fallback to default
+    expect(vars.apiHost).to.equal('api.heroku.com')
+    expect(vars.apiUrl).to.equal('https://api.heroku.com')
+  })
+
+  it('respects legitimate HEROKU_HOST as url', () => {
+    // Test with a valid heroku.com subdomain URL
+    process.env.HEROKU_HOST = 'https://staging.heroku.com'
+    expect(vars.host).to.equal('https://staging.heroku.com')
+    expect(vars.apiHost).to.equal('staging.heroku.com')
+    expect(vars.apiUrl).to.equal('https://staging.heroku.com')
+    expect(vars.gitHost).to.equal('staging.heroku.com')
+    expect(vars.httpGitHost).to.equal('staging.heroku.com')
+    expect(vars.gitPrefixes).to.deep.equal(['git@staging.heroku.com:', 'ssh://git@staging.heroku.com/', 'https://staging.heroku.com/'])
     expect(vars.particleboardUrl).to.equal('https://particleboard.heroku.com')
+  })
+
+  it('rejects invalid HEROKU_HOST URLs', () => {
+    // Test that invalid URL hosts are rejected and fallback to default
+    process.env.HEROKU_HOST = 'https://bogus-server.com'
+    expect(vars.host).to.equal('heroku.com') // Should fallback to default for security
+    expect(vars.apiHost).to.equal('api.heroku.com')
+    expect(vars.apiUrl).to.equal('https://api.heroku.com')
   })
 
   it('respects HEROKU_PARTICLEBOARD_URL', () => {


### PR DESCRIPTION
## Description
Applies the changes from #218 to a branch of this library that supports oclif/core v2.

This PR adds domain validation for making outbound requests. Authentication will only happen for valid domains, and host resolution will only work for valid domains, otherwise defaulting to heroku.com