### PR TITLE
fix: updating to include an alternate url when api.url.com does not exist

### DIFF
--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -169,7 +169,7 @@ export class APIClient {
             targetUrl = new URL(url, vars.apiUrl)
           }
 
-          const isHerokuApi = ALLOWED_HEROKU_DOMAINS.some(domain => targetUrl.hostname.endsWith(`.${domain}`))
+          const isHerokuApi = ALLOWED_HEROKU_DOMAINS.some(domain => targetUrl.hostname.endsWith(`.${domain}`) || targetUrl.hostname === domain)
           const isLocalhost = LOCALHOST_DOMAINS.includes(targetUrl.hostname as (typeof LOCALHOST_DOMAINS)[number])
 
           if (isHerokuApi || isLocalhost) {

--- a/src/vars.ts
+++ b/src/vars.ts
@@ -77,7 +77,7 @@ export class Vars {
     // Remove protocol if present
     const cleanHost = host.replace(/^https?:\/\//, '')
 
-    return ALLOWED_HEROKU_DOMAINS.some(domain => cleanHost.endsWith(`.${domain}`)) || LOCALHOST_DOMAINS.some(domain => cleanHost.includes(domain))
+    return ALLOWED_HEROKU_DOMAINS.some(domain => cleanHost.endsWith(`.${domain}`) || cleanHost === domain) || LOCALHOST_DOMAINS.some(domain => cleanHost.includes(domain))
   }
 }
 


### PR DESCRIPTION
## Description

This change updates the oclif (not to be confused with oclif/core) from 2.2.5 to 4.22.5 and resolves related critical dependencies while maintaining core functionality. 

## Testing
`git checkout command-migrations-oclifv2-set4`
run the following commands
```
npm install && npm run build
HEROKU_HOST=heroku.com npm run example whoami
HEROKU_HOST=herokai.com npm run example whoami
HEROKU_HOST=fakeheroku.com npm run example whoami
```

Note errors should appear only for fakeheroku.com. 

## Screenshots (if applicable)

## SOC2 Compliance

Gus Work Item: [W-19482079](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002L6x2PYAR/view) (Heroku internal)
