### PR TITLE
feat: add warning messages when credential manager keychain ops fail

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "execa": "^9.6.1",
         "inquirer": "^8.2.6",
         "open": "^11.0.0",
+        "tsheredoc": "^1.0.1",
         "yargs-parser": "^20.2.9",
         "yargs-unparser": "^2.0.0"
       },
@@ -8941,6 +8942,12 @@
         "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
       }
+    },
+    "node_modules/tsheredoc": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tsheredoc/-/tsheredoc-1.0.1.tgz",
+      "integrity": "sha512-aOyKWGdZSKEMFnzlccLu3wwB4VgpGhJ6bZON9uM+p8hgHSczfMvPdspxX+Dkr+q8/Dpgla1UwK6pFLmutUEUaw==",
+      "license": "MIT"
     },
     "node_modules/tslib": {
       "version": "2.8.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "execa": "^9.6.1",
     "inquirer": "^8.2.6",
     "open": "^11.0.0",
+    "tsheredoc": "^1.0.1",
     "yargs-parser": "^20.2.9",
     "yargs-unparser": "^2.0.0"
   },

--- a/src/credential-manager-core/index.ts
+++ b/src/credential-manager-core/index.ts
@@ -36,11 +36,11 @@ export async function saveAuth(account: string, token: string, hosts: string[], 
     } catch (error) {
       const {message} = error as Error
       credDebug(message)
-      if (!process.env.KEYCHAIN_ERROR_WARN_OFF) {
+      if (process.env.HEROKU_KEYCHAIN_WARNINGS !== 'off') {
         ux.warn(heredoc(`
           Unable to save Heroku token to ${service}: ${message}.
           Token will be saved to the .netrc file instead.
-          To turn off this warning in the future, set KEYCHAIN_ERROR_WARN_OFF to true.
+          To turn off this warning in the future, set HEROKU_KEYCHAIN_WARNINGS to "off".
         `))
       }
 
@@ -92,11 +92,11 @@ export async function getAuth(account: string | undefined, host: string, service
     } catch (error) {
       const {message} = error as Error
       credDebug(message)
-      if (!process.env.KEYCHAIN_ERROR_WARN_OFF) {
+      if (process.env.HEROKU_KEYCHAIN_WARNINGS !== 'off') {
         ux.warn(heredoc(`
           Unable to retrieve Heroku token from ${service}: ${message}.
           Token will be retrieved from the .netrc file instead.
-          To turn off this warning in the future, set KEYCHAIN_ERROR_WARN_OFF to true.
+          To turn off this warning in the future, set HEROKU_KEYCHAIN_WARNINGS to "off".
         `))
       }
 
@@ -151,10 +151,10 @@ export async function removeAuth(account: string | undefined, hosts: string[], s
     } catch (error) {
       const {message} = error as Error
       credDebug(message)
-      if (!process.env.KEYCHAIN_ERROR_WARN_OFF) {
+      if (process.env.HEROKU_KEYCHAIN_WARNINGS !== 'off') {
         ux.warn(heredoc(`
           Unable to remove Heroku token from ${service}: ${message}.
-          To turn off this warning in the future, set KEYCHAIN_ERROR_WARN_OFF to true.
+          To turn off this warning in the future, set HEROKU_KEYCHAIN_WARNINGS to "off".
         `))
       }
 

--- a/src/credential-manager-core/index.ts
+++ b/src/credential-manager-core/index.ts
@@ -40,8 +40,7 @@ export async function saveAuth(account: string, token: string, hosts: string[], 
         ux.warn(heredoc(`
           Unable to save Heroku token to ${service}: ${message}.
           Token will be saved to the .netrc file instead.
-          To turn off this warning in the future, set HEROKU_KEYCHAIN_WARNINGS to "off".
-        `))
+          To turn off this warning in the future, set HEROKU_KEYCHAIN_WARNINGS to "off".`))
       }
 
       await reportCredentialStoreError(error, {
@@ -154,6 +153,7 @@ export async function removeAuth(account: string | undefined, hosts: string[], s
       if (process.env.HEROKU_KEYCHAIN_WARNINGS !== 'off') {
         ux.warn(heredoc(`
           Unable to remove Heroku token from ${service}: ${message}.
+          Token will be removed from the .netrc file instead.
           To turn off this warning in the future, set HEROKU_KEYCHAIN_WARNINGS to "off".
         `))
       }

--- a/src/credential-manager-core/index.ts
+++ b/src/credential-manager-core/index.ts
@@ -94,7 +94,7 @@ export async function getAuth(account: string | undefined, host: string, service
       if (process.env.HEROKU_KEYCHAIN_WARNINGS !== 'off') {
         ux.warn(heredoc(`
           Unable to retrieve Heroku token from ${service}.
-          Token will be retrieved from the .netrc file instead.
+          We will attempt to retrieve the token from the .netrc file instead.
           To turn off this warning in the future, set HEROKU_KEYCHAIN_WARNINGS to "off".
         `))
       }

--- a/src/credential-manager-core/index.ts
+++ b/src/credential-manager-core/index.ts
@@ -38,9 +38,9 @@ export async function saveAuth(account: string, token: string, hosts: string[], 
       credDebug(message)
       if (process.env.HEROKU_KEYCHAIN_WARNINGS !== 'off') {
         ux.warn(heredoc(`
-          Unable to save Heroku token to ${service}.
-          Token will be saved to the .netrc file instead.
-          To turn off this warning in the future, set HEROKU_KEYCHAIN_WARNINGS to "off".`))
+          We can’t save the Heroku token to ${service}.
+          We'll save the token to the .netrc file instead.
+          To turn off this warning, set HEROKU_KEYCHAIN_WARNINGS to "off".`))
       }
 
       await reportCredentialStoreError(error, {
@@ -93,10 +93,9 @@ export async function getAuth(account: string | undefined, host: string, service
       credDebug(message)
       if (process.env.HEROKU_KEYCHAIN_WARNINGS !== 'off') {
         ux.warn(heredoc(`
-          Unable to retrieve Heroku token from ${service}.
-          We will attempt to retrieve the token from the .netrc file instead.
-          To turn off this warning in the future, set HEROKU_KEYCHAIN_WARNINGS to "off".
-        `))
+          We can’t retrieve the Heroku token from ${service}.
+          We'll try to retrieve the token from the .netrc file instead.
+          To turn off this warning, set HEROKU_KEYCHAIN_WARNINGS to "off".`))
       }
 
       await reportCredentialStoreError(error, {
@@ -152,10 +151,9 @@ export async function removeAuth(account: string | undefined, hosts: string[], s
       credDebug(message)
       if (process.env.HEROKU_KEYCHAIN_WARNINGS !== 'off') {
         ux.warn(heredoc(`
-          Unable to remove Heroku token from ${service}.
-          Token will be removed from the .netrc file instead.
-          To turn off this warning in the future, set HEROKU_KEYCHAIN_WARNINGS to "off".
-        `))
+          We can’t remove the Heroku token from ${service}.
+          We'll remove the token from the .netrc file instead.
+          To turn off this warning, set HEROKU_KEYCHAIN_WARNINGS to "off".`))
       }
 
       await reportCredentialStoreError(error, {

--- a/src/credential-manager-core/index.ts
+++ b/src/credential-manager-core/index.ts
@@ -38,7 +38,7 @@ export async function saveAuth(account: string, token: string, hosts: string[], 
       credDebug(message)
       if (process.env.HEROKU_KEYCHAIN_WARNINGS !== 'off') {
         ux.warn(heredoc(`
-          Unable to save Heroku token to ${service}: ${message}.
+          Unable to save Heroku token to ${service}.
           Token will be saved to the .netrc file instead.
           To turn off this warning in the future, set HEROKU_KEYCHAIN_WARNINGS to "off".`))
       }
@@ -93,7 +93,7 @@ export async function getAuth(account: string | undefined, host: string, service
       credDebug(message)
       if (process.env.HEROKU_KEYCHAIN_WARNINGS !== 'off') {
         ux.warn(heredoc(`
-          Unable to retrieve Heroku token from ${service}: ${message}.
+          Unable to retrieve Heroku token from ${service}.
           Token will be retrieved from the .netrc file instead.
           To turn off this warning in the future, set HEROKU_KEYCHAIN_WARNINGS to "off".
         `))
@@ -152,7 +152,7 @@ export async function removeAuth(account: string | undefined, hosts: string[], s
       credDebug(message)
       if (process.env.HEROKU_KEYCHAIN_WARNINGS !== 'off') {
         ux.warn(heredoc(`
-          Unable to remove Heroku token from ${service}: ${message}.
+          Unable to remove Heroku token from ${service}.
           Token will be removed from the .netrc file instead.
           To turn off this warning in the future, set HEROKU_KEYCHAIN_WARNINGS to "off".
         `))

--- a/src/credential-manager-core/index.ts
+++ b/src/credential-manager-core/index.ts
@@ -90,7 +90,6 @@ export async function getAuth(account: string | undefined, host: string, service
       config.useNetrc = true
     } catch (error) {
       const {message} = error as Error
-      console.log('error message', message)
       credDebug(message)
       if (process.env.HEROKU_KEYCHAIN_WARNINGS !== 'off') {
         ux.warn(heredoc(`

--- a/src/credential-manager-core/index.ts
+++ b/src/credential-manager-core/index.ts
@@ -90,6 +90,7 @@ export async function getAuth(account: string | undefined, host: string, service
       config.useNetrc = true
     } catch (error) {
       const {message} = error as Error
+      console.log('error message', message)
       credDebug(message)
       if (process.env.HEROKU_KEYCHAIN_WARNINGS !== 'off') {
         ux.warn(heredoc(`

--- a/src/credential-manager-core/index.ts
+++ b/src/credential-manager-core/index.ts
@@ -1,4 +1,6 @@
+import {ux} from '@oclif/core'
 import debug from 'debug'
+import tsheredoc from 'tsheredoc'
 
 import {LinuxHandler} from './credential-handlers/linux-handler.js'
 import {MacOSHandler} from './credential-handlers/macos-handler.js'
@@ -10,6 +12,7 @@ import {CredentialStore, getStorageConfig} from './lib/credential-storage-select
 import {NetrcAuthEntry} from './lib/types.js'
 
 const credDebug = debug('heroku-credential-manager')
+const heredoc = tsheredoc.default
 
 const SERVICE_NAME = 'heroku-cli'
 
@@ -33,6 +36,14 @@ export async function saveAuth(account: string, token: string, hosts: string[], 
     } catch (error) {
       const {message} = error as Error
       credDebug(message)
+      if (!process.env.KEYCHAIN_ERROR_WARN_OFF) {
+        ux.warn(heredoc(`
+          Unable to save Heroku token to ${service}: ${message}.
+          Token will be saved to the .netrc file instead.
+          To turn off this warning in the future, set KEYCHAIN_ERROR_WARN_OFF to true.
+        `))
+      }
+
       await reportCredentialStoreError(error, {
         credentialStore: config.credentialStore,
         operation: 'saveAuth',
@@ -81,6 +92,14 @@ export async function getAuth(account: string | undefined, host: string, service
     } catch (error) {
       const {message} = error as Error
       credDebug(message)
+      if (!process.env.KEYCHAIN_ERROR_WARN_OFF) {
+        ux.warn(heredoc(`
+          Unable to retrieve Heroku token from ${service}: ${message}.
+          Token will be retrieved from the .netrc file instead.
+          To turn off this warning in the future, set KEYCHAIN_ERROR_WARN_OFF to true.
+        `))
+      }
+
       await reportCredentialStoreError(error, {
         credentialStore: config.credentialStore,
         operation: 'getAuth',
@@ -132,6 +151,13 @@ export async function removeAuth(account: string | undefined, hosts: string[], s
     } catch (error) {
       const {message} = error as Error
       credDebug(message)
+      if (!process.env.KEYCHAIN_ERROR_WARN_OFF) {
+        ux.warn(heredoc(`
+          Unable to remove Heroku token from ${service}: ${message}.
+          To turn off this warning in the future, set KEYCHAIN_ERROR_WARN_OFF to true.
+        `))
+      }
+
       await reportCredentialStoreError(error, {
         credentialStore: config.credentialStore,
         operation: 'removeAuth',

--- a/test/credential-manager/acceptance/index.acceptance.test.ts
+++ b/test/credential-manager/acceptance/index.acceptance.test.ts
@@ -119,7 +119,7 @@ describe('credential-manager acceptance', function () {
     })
 
     // We save with `hosts = []` to test the keychain-only path
-    it('saves and retrieves an entry', async function () {
+    it.skip('saves and retrieves an entry', async function () {
       await saveAuth(CREDENTIAL.account, CREDENTIAL.token, [], CREDENTIAL.service)
 
       const token = await getAuth(CREDENTIAL.account, 'missing.host.example.com', CREDENTIAL.service)

--- a/test/credential-manager/acceptance/index.acceptance.test.ts
+++ b/test/credential-manager/acceptance/index.acceptance.test.ts
@@ -83,7 +83,7 @@ describe('credential-manager acceptance', function () {
       .to.be.rejectedWith(/No auth found|No credentials found/)
     })
 
-    it.skip('removes multiple hosts', async function () {
+    it('removes multiple hosts', async function () {
       await saveAuth(CREDENTIAL_MULTIPLE_HOSTS.account, CREDENTIAL_MULTIPLE_HOSTS.token, CREDENTIAL_MULTIPLE_HOSTS.hosts, CREDENTIAL_MULTIPLE_HOSTS.service)
       await removeAuth(CREDENTIAL_MULTIPLE_HOSTS.account, CREDENTIAL_MULTIPLE_HOSTS.hosts, CREDENTIAL_MULTIPLE_HOSTS.service)
 
@@ -127,12 +127,15 @@ describe('credential-manager acceptance', function () {
     })
 
     it('removes an entry', async function () {
+      process.env.HEROKU_KEYCHAIN_WARNINGS = 'off'
       await saveAuth(CREDENTIAL.account, CREDENTIAL.token, [], CREDENTIAL.service)
       await removeAuth(CREDENTIAL.account, [], CREDENTIAL.service)
 
       await expect(
 				getAuth(CREDENTIAL.account, 'missing.host.example.com', CREDENTIAL.service),
 			).to.be.rejectedWith(/No auth found|No credentials found/)
+
+      delete process.env.HEROKU_KEYCHAIN_WARNINGS
     })
 
     it('updates entry when account already has credentials', async function () {

--- a/test/credential-manager/acceptance/index.acceptance.test.ts
+++ b/test/credential-manager/acceptance/index.acceptance.test.ts
@@ -58,14 +58,14 @@ describe('credential-manager acceptance', function () {
       delete process.env.HEROKU_NETRC_WRITE
     })
 
-    it.skip('saves/retrieves a single host', async function () {
+    it('saves/retrieves a single host', async function () {
       await saveAuth(CREDENTIAL.account, CREDENTIAL.token, CREDENTIAL.hosts, CREDENTIAL.service)
 
       const token = await getAuth(CREDENTIAL.account, CREDENTIAL.hosts[0], CREDENTIAL.service)
       expect(token).to.equal(CREDENTIAL.token)
     })
 
-    it.skip('saves/retrieves multiple hosts', async function () {
+    it('saves/retrieves multiple hosts', async function () {
       await saveAuth(CREDENTIAL_MULTIPLE_HOSTS.account, CREDENTIAL_MULTIPLE_HOSTS.token, CREDENTIAL_MULTIPLE_HOSTS.hosts, CREDENTIAL_MULTIPLE_HOSTS.service)
 
       const token1 = await getAuth(CREDENTIAL_MULTIPLE_HOSTS.account, CREDENTIAL_MULTIPLE_HOSTS.hosts[0], CREDENTIAL_MULTIPLE_HOSTS.service)
@@ -75,7 +75,7 @@ describe('credential-manager acceptance', function () {
       expect(token2).to.equal(CREDENTIAL_MULTIPLE_HOSTS.token)
     })
 
-    it.skip('removes a single host', async function () {
+    it('removes a single host', async function () {
       await saveAuth(CREDENTIAL.account, CREDENTIAL.token, CREDENTIAL.hosts, CREDENTIAL.service)
       await removeAuth(CREDENTIAL.account, CREDENTIAL.hosts, CREDENTIAL.service)
 
@@ -83,7 +83,7 @@ describe('credential-manager acceptance', function () {
       .to.be.rejectedWith(/No auth found|No credentials found/)
     })
 
-    it('removes multiple hosts', async function () {
+    it.skip('removes multiple hosts', async function () {
       await saveAuth(CREDENTIAL_MULTIPLE_HOSTS.account, CREDENTIAL_MULTIPLE_HOSTS.token, CREDENTIAL_MULTIPLE_HOSTS.hosts, CREDENTIAL_MULTIPLE_HOSTS.service)
       await removeAuth(CREDENTIAL_MULTIPLE_HOSTS.account, CREDENTIAL_MULTIPLE_HOSTS.hosts, CREDENTIAL_MULTIPLE_HOSTS.service)
 
@@ -93,7 +93,7 @@ describe('credential-manager acceptance', function () {
       .to.be.rejectedWith(/No auth found|No credentials found/)
     })
 
-    it('updates entry when host already has credentials', async function () {
+    it.skip('updates entry when host already has credentials', async function () {
       await saveAuth(CREDENTIAL.account, CREDENTIAL.token, CREDENTIAL.hosts, CREDENTIAL.service)
       await saveAuth(CREDENTIAL.account, 'new-token', CREDENTIAL.hosts, CREDENTIAL.service)
 
@@ -101,7 +101,7 @@ describe('credential-manager acceptance', function () {
       expect(token).to.equal('new-token')
     })
 
-    it('skips credential store', async function () {
+    it.skip('skips credential store', async function () {
       await saveAuth(CREDENTIAL.account, CREDENTIAL.token, CREDENTIAL.hosts, CREDENTIAL.service)
 
       const {accounts} = listCredentialStoreAccounts(CREDENTIAL.service)

--- a/test/credential-manager/acceptance/index.acceptance.test.ts
+++ b/test/credential-manager/acceptance/index.acceptance.test.ts
@@ -127,6 +127,7 @@ describe('credential-manager acceptance', function () {
     })
 
     it('removes an entry', async function () {
+      // suppressing the keychain warning message since it is not relevant to this test
       process.env.HEROKU_KEYCHAIN_WARNINGS = 'off'
       await saveAuth(CREDENTIAL.account, CREDENTIAL.token, [], CREDENTIAL.service)
       await removeAuth(CREDENTIAL.account, [], CREDENTIAL.service)
@@ -197,7 +198,7 @@ describe('credential-manager acceptance', function () {
       .to.be.rejectedWith(/No auth found|No credentials found/)
     })
 
-    it('saves to netrc when credential store fails', async function () {
+    it.skip('saves to netrc when credential store fails', async function () {
       await saveAuth(CREDENTIAL.account, CREDENTIAL.token, CREDENTIAL.hosts, CREDENTIAL.service)
 
       stderr.start()

--- a/test/credential-manager/acceptance/index.acceptance.test.ts
+++ b/test/credential-manager/acceptance/index.acceptance.test.ts
@@ -101,7 +101,7 @@ describe('credential-manager acceptance', function () {
       expect(token).to.equal('new-token')
     })
 
-    it('skips credential store', async function () {
+    it.skip('skips credential store', async function () {
       await saveAuth(CREDENTIAL.account, CREDENTIAL.token, CREDENTIAL.hosts, CREDENTIAL.service)
 
       const {accounts} = listCredentialStoreAccounts(CREDENTIAL.service)
@@ -119,7 +119,7 @@ describe('credential-manager acceptance', function () {
     })
 
     // We save with `hosts = []` to test the keychain-only path
-    it.skip('saves and retrieves an entry', async function () {
+    it('saves and retrieves an entry', async function () {
       await saveAuth(CREDENTIAL.account, CREDENTIAL.token, [], CREDENTIAL.service)
 
       const token = await getAuth(CREDENTIAL.account, 'missing.host.example.com', CREDENTIAL.service)

--- a/test/credential-manager/acceptance/index.acceptance.test.ts
+++ b/test/credential-manager/acceptance/index.acceptance.test.ts
@@ -1,5 +1,6 @@
 import {expect, use} from 'chai'
 import chaiAsPromised from 'chai-as-promised'
+import {stderr} from 'stdout-stderr'
 
 import {getAuth, removeAuth, saveAuth} from '../../../src/credential-manager-core/index.js'
 
@@ -11,6 +12,7 @@ import {
   snapshotDefaultNetrc,
   skipUnlessAcceptance,
 } from '../helpers/acceptance-utils.js'
+import { unwrap } from '../../helpers/unwrap.js'
 
 use(chaiAsPromised)
 
@@ -190,6 +192,20 @@ describe('credential-manager acceptance', function () {
 
       await expect(getAuth(CREDENTIAL.account, CREDENTIAL.hosts[0], CREDENTIAL.service))
       .to.be.rejectedWith(/No auth found|No credentials found/)
+    })
+
+    it('saves to netrc when credential store fails', async function () {
+      await saveAuth(CREDENTIAL.account, CREDENTIAL.token, CREDENTIAL.hosts, CREDENTIAL.service)
+
+      stderr.start()
+
+      const netrcToken = await getAuth('missing-account@example.com', CREDENTIAL.hosts[0], CREDENTIAL.service)
+      expect(netrcToken).to.equal(CREDENTIAL.token)
+      expect(unwrap(stderr.output)).to.contain('Warning: Unable to save Heroku token to heroku-cli: Keychain error.')
+      expect(unwrap(stderr.output)).to.contain('Token will be saved to the .netrc file instead.')
+      expect(unwrap(stderr.output)).to.contain('To turn off this warning in the future, set HEROKU_KEYCHAIN_WARNINGS to "off".')
+
+      stderr.stop()
     })
 
     it('retrieves via netrc when credential store fails', async function () {

--- a/test/credential-manager/acceptance/index.acceptance.test.ts
+++ b/test/credential-manager/acceptance/index.acceptance.test.ts
@@ -93,7 +93,7 @@ describe('credential-manager acceptance', function () {
       .to.be.rejectedWith(/No auth found|No credentials found/)
     })
 
-    it.skip('updates entry when host already has credentials', async function () {
+    it('updates entry when host already has credentials', async function () {
       await saveAuth(CREDENTIAL.account, CREDENTIAL.token, CREDENTIAL.hosts, CREDENTIAL.service)
       await saveAuth(CREDENTIAL.account, 'new-token', CREDENTIAL.hosts, CREDENTIAL.service)
 
@@ -101,7 +101,7 @@ describe('credential-manager acceptance', function () {
       expect(token).to.equal('new-token')
     })
 
-    it.skip('skips credential store', async function () {
+    it('skips credential store', async function () {
       await saveAuth(CREDENTIAL.account, CREDENTIAL.token, CREDENTIAL.hosts, CREDENTIAL.service)
 
       const {accounts} = listCredentialStoreAccounts(CREDENTIAL.service)

--- a/test/credential-manager/acceptance/index.acceptance.test.ts
+++ b/test/credential-manager/acceptance/index.acceptance.test.ts
@@ -58,14 +58,14 @@ describe('credential-manager acceptance', function () {
       delete process.env.HEROKU_NETRC_WRITE
     })
 
-    it('saves/retrieves a single host', async function () {
+    it.skip('saves/retrieves a single host', async function () {
       await saveAuth(CREDENTIAL.account, CREDENTIAL.token, CREDENTIAL.hosts, CREDENTIAL.service)
 
       const token = await getAuth(CREDENTIAL.account, CREDENTIAL.hosts[0], CREDENTIAL.service)
       expect(token).to.equal(CREDENTIAL.token)
     })
 
-    it('saves/retrieves multiple hosts', async function () {
+    it.skip('saves/retrieves multiple hosts', async function () {
       await saveAuth(CREDENTIAL_MULTIPLE_HOSTS.account, CREDENTIAL_MULTIPLE_HOSTS.token, CREDENTIAL_MULTIPLE_HOSTS.hosts, CREDENTIAL_MULTIPLE_HOSTS.service)
 
       const token1 = await getAuth(CREDENTIAL_MULTIPLE_HOSTS.account, CREDENTIAL_MULTIPLE_HOSTS.hosts[0], CREDENTIAL_MULTIPLE_HOSTS.service)
@@ -75,7 +75,7 @@ describe('credential-manager acceptance', function () {
       expect(token2).to.equal(CREDENTIAL_MULTIPLE_HOSTS.token)
     })
 
-    it('removes a single host', async function () {
+    it.skip('removes a single host', async function () {
       await saveAuth(CREDENTIAL.account, CREDENTIAL.token, CREDENTIAL.hosts, CREDENTIAL.service)
       await removeAuth(CREDENTIAL.account, CREDENTIAL.hosts, CREDENTIAL.service)
 
@@ -101,7 +101,7 @@ describe('credential-manager acceptance', function () {
       expect(token).to.equal('new-token')
     })
 
-    it.skip('skips credential store', async function () {
+    it('skips credential store', async function () {
       await saveAuth(CREDENTIAL.account, CREDENTIAL.token, CREDENTIAL.hosts, CREDENTIAL.service)
 
       const {accounts} = listCredentialStoreAccounts(CREDENTIAL.service)

--- a/test/credential-manager/acceptance/index.acceptance.test.ts
+++ b/test/credential-manager/acceptance/index.acceptance.test.ts
@@ -213,9 +213,9 @@ describe('credential-manager acceptance', function () {
         await saveAuth(CREDENTIAL.account, CREDENTIAL.token, CREDENTIAL.hosts, CREDENTIAL.service)
         stderr.stop()
 
-        expect(unwrap(stderr.output)).to.contain('Unable to save Heroku token to heroku-cli-acceptance-test.')
-        expect(unwrap(stderr.output)).to.contain('Token will be saved to the .netrc file instead.')
-        expect(unwrap(stderr.output)).to.contain('To turn off this warning in the future, set HEROKU_KEYCHAIN_WARNINGS to "off".')
+        expect(unwrap(stderr.output)).to.contain('We can’t save the Heroku token to heroku-cli-acceptance-test.')
+        expect(unwrap(stderr.output)).to.contain('We\'ll save the token to the .netrc file instead.')
+        expect(unwrap(stderr.output)).to.contain('To turn off this warning, set HEROKU_KEYCHAIN_WARNINGS to "off".')
 
         const netrcToken = await getAuth('missing-account@example.com', CREDENTIAL.hosts[0], CREDENTIAL.service)
         expect(netrcToken).to.equal(CREDENTIAL.token)

--- a/test/credential-manager/acceptance/index.acceptance.test.ts
+++ b/test/credential-manager/acceptance/index.acceptance.test.ts
@@ -9,8 +9,9 @@ import {
   cleanupCredentialStore,
   cleanupDefaultNetrc,
   listCredentialStoreAccounts,
-  snapshotDefaultNetrc,
+  setupFakeCredentialStore,
   skipUnlessAcceptance,
+  snapshotDefaultNetrc,
 } from '../helpers/acceptance-utils.js'
 import { unwrap } from '../../helpers/unwrap.js'
 
@@ -198,18 +199,29 @@ describe('credential-manager acceptance', function () {
       .to.be.rejectedWith(/No auth found|No credentials found/)
     })
 
-    it.skip('saves to netrc when credential store fails', async function () {
-      await saveAuth(CREDENTIAL.account, CREDENTIAL.token, CREDENTIAL.hosts, CREDENTIAL.service)
+    it('saves to netrc when credential store fails', async function () {
+      // Set up fake credential store command for the current platform
+      const fakeSetup = setupFakeCredentialStore()
 
-      stderr.start()
+      if (!fakeSetup) {
+        // Skip if credential store not available on this platform
+        this.skip()
+      }
 
-      const netrcToken = await getAuth('missing-account@example.com', CREDENTIAL.hosts[0], CREDENTIAL.service)
-      expect(netrcToken).to.equal(CREDENTIAL.token)
-      expect(unwrap(stderr.output)).to.contain('Warning: Unable to save Heroku token to heroku-cli-acceptance-test.')
-      expect(unwrap(stderr.output)).to.contain('Token will be saved to the .netrc file instead.')
-      expect(unwrap(stderr.output)).to.contain('To turn off this warning in the future, set HEROKU_KEYCHAIN_WARNINGS to "off".')
+      try {
+        stderr.start()
+        await saveAuth(CREDENTIAL.account, CREDENTIAL.token, CREDENTIAL.hosts, CREDENTIAL.service)
+        stderr.stop()
 
-      stderr.stop()
+        expect(unwrap(stderr.output)).to.contain('Unable to save Heroku token to heroku-cli-acceptance-test.')
+        expect(unwrap(stderr.output)).to.contain('Token will be saved to the .netrc file instead.')
+        expect(unwrap(stderr.output)).to.contain('To turn off this warning in the future, set HEROKU_KEYCHAIN_WARNINGS to "off".')
+
+        const netrcToken = await getAuth('missing-account@example.com', CREDENTIAL.hosts[0], CREDENTIAL.service)
+        expect(netrcToken).to.equal(CREDENTIAL.token)
+      } finally {
+        fakeSetup.cleanup()
+      }
     })
 
     it('retrieves via netrc when credential store fails', async function () {

--- a/test/credential-manager/acceptance/index.acceptance.test.ts
+++ b/test/credential-manager/acceptance/index.acceptance.test.ts
@@ -201,7 +201,7 @@ describe('credential-manager acceptance', function () {
 
       const netrcToken = await getAuth('missing-account@example.com', CREDENTIAL.hosts[0], CREDENTIAL.service)
       expect(netrcToken).to.equal(CREDENTIAL.token)
-      expect(unwrap(stderr.output)).to.contain('Warning: Unable to save Heroku token to heroku-cli: Keychain error.')
+      expect(unwrap(stderr.output)).to.contain('Warning: Unable to save Heroku token to heroku-cli-acceptance-test.')
       expect(unwrap(stderr.output)).to.contain('Token will be saved to the .netrc file instead.')
       expect(unwrap(stderr.output)).to.contain('To turn off this warning in the future, set HEROKU_KEYCHAIN_WARNINGS to "off".')
 

--- a/test/credential-manager/helpers/acceptance-utils.test.ts
+++ b/test/credential-manager/helpers/acceptance-utils.test.ts
@@ -7,15 +7,19 @@ import {MacOSHandler, Netrc} from '../../../src/credential-manager-core/index.js
 import {
   ALTERNATE_HOST_NAME,
   ALTERNATE_SERVICE_NAME,
-  HOST_NAME,
-  SERVICE_NAME,
   cleanupCredentialStore,
   cleanupDefaultNetrc,
   getAllAcceptanceHosts,
   getAllAcceptanceServices,
+  HOST_NAME,
+  isPowerShellAvailable,
+  isSecretToolAvailable,
+  isSecurityAvailable,
   listCredentialStoreAccounts,
-  snapshotDefaultNetrc,
+  SERVICE_NAME,
+  setupFakeCredentialStore,
   skipUnlessAcceptance,
+  snapshotDefaultNetrc,
 } from './acceptance-utils.js'
 
 describe('acceptance utils', function () {
@@ -231,6 +235,48 @@ describe('acceptance utils', function () {
       expect(readFileSyncStub.notCalled).to.equal(true)
       expect(writeFileSyncStub.notCalled).to.equal(true)
       expect(rmSyncStub.calledOnceWithExactly(netrcPath, {force: true})).to.equal(true)
+    })
+  })
+
+  // Integration-style tests that don't require stubbing ES modules
+  describe('isSecretToolAvailable', function () {
+    it('returns a boolean', function () {
+      const result = isSecretToolAvailable()
+      expect(typeof result).to.equal('boolean')
+    })
+  })
+
+  describe('isSecurityAvailable', function () {
+    it('returns a boolean', function () {
+      const result = isSecurityAvailable()
+      expect(typeof result).to.equal('boolean')
+    })
+  })
+
+  describe('isPowerShellAvailable', function () {
+    it('returns a boolean', function () {
+      const result = isPowerShellAvailable()
+      expect(typeof result).to.equal('boolean')
+    })
+  })
+
+  describe('setupFakeCredentialStore', function () {
+    it('returns undefined or a setup object with cleanup', function () {
+      const setup = setupFakeCredentialStore()
+
+      if (setup) {
+        expect(setup).to.have.property('cleanup')
+        expect(setup).to.have.property('originalPath')
+        expect(setup).to.have.property('tmpDir')
+        expect(typeof setup.cleanup).to.equal('function')
+        expect(typeof setup.originalPath).to.equal('string')
+        expect(typeof setup.tmpDir).to.equal('string')
+
+        // Cleanup after test
+        setup.cleanup()
+      } else {
+        expect(setup).to.equal(undefined)
+      }
     })
   })
 })

--- a/test/credential-manager/helpers/acceptance-utils.ts
+++ b/test/credential-manager/helpers/acceptance-utils.ts
@@ -1,7 +1,10 @@
+import {Context} from 'mocha'
+import {execSync} from 'node:child_process'
 import fs from 'node:fs'
+import path from 'node:path'
+
 import {getCredentialHandler, getStorageConfig} from '../../../src/credential-manager-core/index.js'
 import {Netrc} from '../../../src/credential-manager-core/lib/netrc-parser.js'
-import {Context} from 'mocha'
 
 export type AcceptanceFixture = {
   account: string,
@@ -21,6 +24,12 @@ export const SERVICE_NAME = 'heroku-cli-acceptance-test'
 export const ALTERNATE_SERVICE_NAME = 'heroku-cli-acceptance-test-alternate'
 
 export const CREDENTIAL_FIXTURES = {
+  'account-alternate-service': {
+    account: 'test-alternate-service@example.com',
+    hosts: [HOST_NAME],
+    service: ALTERNATE_SERVICE_NAME,
+    token: 'test-token-alternate-service-12345',
+  },
   'account-default': {
     account: 'test@example.com',
     hosts: [HOST_NAME],
@@ -32,12 +41,6 @@ export const CREDENTIAL_FIXTURES = {
     hosts: [HOST_NAME, ALTERNATE_HOST_NAME],
     service: SERVICE_NAME,
     token: 'test-token-multiple-hosts-12345',
-  },
-  'account-alternate-service': {
-    account: 'test-alternate-service@example.com',
-    hosts: [HOST_NAME],
-    service: ALTERNATE_SERVICE_NAME,
-    token: 'test-token-alternate-service-12345',
   },
 } as const satisfies Record<string, AcceptanceFixture>
 
@@ -68,13 +71,13 @@ export async function cleanupDefaultNetrc(): Promise<void> {
 export function cleanupCredentialStore(): void {
   const services = getAllAcceptanceServices()
   for (const service of services) {
-  const {handler, accounts} = listCredentialStoreAccounts(service)
-  if (!handler) return
+    const {accounts, handler} = listCredentialStoreAccounts(service)
+    if (!handler) return
 
-  for (const account of accounts) {
-    handler.removeAuth(account, service)
+    for (const account of accounts) {
+      handler.removeAuth(account, service)
+    }
   }
-}
 }
 
 /**
@@ -102,7 +105,7 @@ export function listCredentialStoreAccounts(service: string) {
   const handler = getCredentialHandler(credentialStore)
   const accounts = handler.listAccounts(service)
 
-  return {handler, accounts}
+  return {accounts, handler}
 }
 
 /**
@@ -144,5 +147,168 @@ export function snapshotDefaultNetrc(): NetrcSnapshot {
 
       restored = true
     },
+  }
+}
+
+export type FakeCredentialStoreSetup = {
+  cleanup: () => void
+  originalPath: string
+  tmpDir: string
+}
+
+/**
+ * Creates a fake credential store command that always fails.
+ * Used for testing credential store fallback behavior.
+ *
+ * The fake command is placed in a temporary directory that is prepended to PATH,
+ * ensuring it's found before the real command.
+ *
+ * @param commandName - The command to fake (e.g., 'secret-tool', 'security', 'powershell')
+ * @param scriptContent - The script content for the fake command
+ * @returns An object with the original PATH and a cleanup function to restore state
+ */
+function setupFakeCommand(commandName: string, scriptContent: string): FakeCredentialStoreSetup {
+  // Create a temporary directory for our fake command
+  const tmpPrefix = process.platform === 'win32' ? process.env.TEMP || String.raw`C:\temp` : '/tmp'
+  const tmpDir = fs.mkdtempSync(path.join(tmpPrefix, 'keyring-test-'))
+  const fakeCommand = path.join(tmpDir, commandName)
+
+  // Create a fake command that always fails
+  fs.writeFileSync(fakeCommand, scriptContent, {mode: 0o755})
+
+  // Prepend our temp directory to PATH so our fake command is found first
+  const originalPath = process.env.PATH || ''
+  const pathSeparator = process.platform === 'win32' ? ';' : ':'
+  process.env.PATH = `${tmpDir}${pathSeparator}${originalPath}`
+
+  return {
+    cleanup() {
+      // Restore PATH
+      process.env.PATH = originalPath
+
+      // Remove temporary directory
+      try {
+        fs.rmSync(tmpDir, {force: true, recursive: true})
+      } catch {
+        // Best effort cleanup
+      }
+    },
+    originalPath,
+    tmpDir,
+  }
+}
+
+/**
+ * Creates a fake secret-tool executable that always fails.
+ * Used for testing credential store fallback behavior on Linux.
+ *
+ * The fake secret-tool is placed in a temporary directory that is prepended to PATH,
+ * ensuring it's found before the real secret-tool.
+ *
+ * @returns An object with the original PATH and a cleanup function to restore state
+ */
+export function setupFakeSecretTool(): FakeCredentialStoreSetup {
+  return setupFakeCommand('secret-tool', '#!/bin/bash\nexit 1\n')
+}
+
+/**
+ * Creates a fake security command that always fails.
+ * Used for testing credential store fallback behavior on macOS.
+ *
+ * The fake security command is placed in a temporary directory that is prepended to PATH,
+ * ensuring it's found before the real security command.
+ *
+ * @returns An object with the original PATH and a cleanup function to restore state
+ */
+export function setupFakeSecurity(): FakeCredentialStoreSetup {
+  return setupFakeCommand('security', '#!/bin/bash\nexit 1\n')
+}
+
+/**
+ * Creates a fake powershell command that always fails.
+ * Used for testing credential store fallback behavior on Windows.
+ *
+ * The fake powershell command is placed in a temporary directory that is prepended to PATH,
+ * ensuring it's found before the real powershell command.
+ *
+ * @returns An object with the original PATH and a cleanup function to restore state
+ */
+export function setupFakePowerShell(): FakeCredentialStoreSetup {
+  const scriptContent = process.platform === 'win32'
+    ? '@echo off\r\nexit /b 1\r\n'
+    : '#!/bin/bash\nexit 1\n'
+
+  const commandName = process.platform === 'win32' ? 'powershell.exe' : 'powershell'
+  return setupFakeCommand(commandName, scriptContent)
+}
+
+/**
+ * Sets up a fake credential store command appropriate for the current platform.
+ * - Linux: fake secret-tool
+ * - macOS: fake security
+ * - Windows: fake powershell
+ *
+ * @returns An object with the original PATH and a cleanup function to restore state, or undefined if platform is not supported
+ */
+export function setupFakeCredentialStore(): FakeCredentialStoreSetup | undefined {
+  switch (process.platform) {
+  case 'darwin': {
+    if (!isSecurityAvailable()) return undefined
+    return setupFakeSecurity()
+  }
+
+  case 'linux': {
+    if (!isSecretToolAvailable()) return undefined
+    return setupFakeSecretTool()
+  }
+
+  case 'win32': {
+    if (!isPowerShellAvailable()) return undefined
+    return setupFakePowerShell()
+  }
+
+  default: {
+    return undefined
+  }
+  }
+}
+
+/**
+ * Checks if secret-tool is available on the system.
+ * @returns true if secret-tool is available, false otherwise
+ */
+export function isSecretToolAvailable(): boolean {
+  try {
+    execSync('which secret-tool', {encoding: 'utf8', stdio: 'pipe'})
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Checks if security command is available on the system (macOS).
+ * @returns true if security is available, false otherwise
+ */
+export function isSecurityAvailable(): boolean {
+  try {
+    execSync('which security', {encoding: 'utf8', stdio: 'pipe'})
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Checks if powershell is available on the system (Windows).
+ * @returns true if powershell is available, false otherwise
+ */
+export function isPowerShellAvailable(): boolean {
+  try {
+    const command = process.platform === 'win32' ? 'where powershell' : 'which powershell'
+    execSync(command, {encoding: 'utf8', stdio: 'pipe'})
+    return true
+  } catch {
+    return false
   }
 }

--- a/test/credential-manager/index.test.ts
+++ b/test/credential-manager/index.test.ts
@@ -70,9 +70,9 @@ describe('credential-manager', function () {
 
       expect(macosStub.calledOnce).to.be.true
       expect(netrcStub.calledOnce).to.be.true
-      expect(unwrap(stderr.output)).to.contain('Warning: Unable to save Heroku token to heroku-cli.')
-      expect(unwrap(stderr.output)).to.contain('Token will be saved to the .netrc file instead.')
-      expect(unwrap(stderr.output)).to.contain('To turn off this warning in the future, set HEROKU_KEYCHAIN_WARNINGS to "off".')
+      expect(unwrap(stderr.output)).to.contain('Warning: We can’t save the Heroku token to heroku-cli.')
+      expect(unwrap(stderr.output)).to.contain('We\'ll save the token to the .netrc file instead.')
+      expect(unwrap(stderr.output)).to.contain('To turn off this warning, set HEROKU_KEYCHAIN_WARNINGS to "off".')
 
       stderr.stop()
     })
@@ -152,9 +152,9 @@ describe('credential-manager', function () {
       expect(macosStub.calledOnce).to.be.true
       expect(netrcStub.calledOnce).to.be.true
       expect(netrcStub.firstCall.args[0]).to.equal('api.heroku.com')
-      expect(unwrap(stderr.output)).to.contain('Warning: Unable to retrieve Heroku token from heroku-cli.')
-      expect(unwrap(stderr.output)).to.contain('We will attempt to retrieve the token from the .netrc file instead.')
-      expect(unwrap(stderr.output)).to.contain('To turn off this warning in the future, set HEROKU_KEYCHAIN_WARNINGS to "off".')
+      expect(unwrap(stderr.output)).to.contain('Warning: We can’t retrieve the Heroku token from heroku-cli.')
+      expect(unwrap(stderr.output)).to.contain('We\'ll try to retrieve the token from the .netrc file instead.')
+      expect(unwrap(stderr.output)).to.contain('To turn off this warning, set HEROKU_KEYCHAIN_WARNINGS to "off".')
 
       stderr.stop()
     })
@@ -170,9 +170,9 @@ describe('credential-manager', function () {
         .to.be.rejectedWith(Error, 'No auth found for api.heroku.com')
       expect(macosStub.calledOnce).to.be.true
       expect(netrcStub.calledOnce).to.be.true
-      expect(unwrap(stderr.output)).to.contain('Warning: Unable to retrieve Heroku token from heroku-cli.')
-      expect(unwrap(stderr.output)).to.contain('We will attempt to retrieve the token from the .netrc file instead.')
-      expect(unwrap(stderr.output)).to.contain('To turn off this warning in the future, set HEROKU_KEYCHAIN_WARNINGS to "off".')
+      expect(unwrap(stderr.output)).to.contain('Warning: We can’t retrieve the Heroku token from heroku-cli.')
+      expect(unwrap(stderr.output)).to.contain('We\'ll try to retrieve the token from the .netrc file instead.')
+      expect(unwrap(stderr.output)).to.contain('To turn off this warning, set HEROKU_KEYCHAIN_WARNINGS to "off".')
 
       stderr.stop()
     })
@@ -188,9 +188,9 @@ describe('credential-manager', function () {
         .to.be.rejectedWith(Error, 'No credentials found. Please log in.')
       expect(macosStub.calledOnce).to.be.true
       expect(netrcStub.calledOnce).to.be.true
-      expect(unwrap(stderr.output)).to.contain('Warning: Unable to retrieve Heroku token from heroku-cli.')
-      expect(unwrap(stderr.output)).to.contain('We will attempt to retrieve the token from the .netrc file instead.')
-      expect(unwrap(stderr.output)).to.contain('To turn off this warning in the future, set HEROKU_KEYCHAIN_WARNINGS to "off".')
+      expect(unwrap(stderr.output)).to.contain('Warning: We can’t retrieve the Heroku token from heroku-cli.')
+      expect(unwrap(stderr.output)).to.contain('We\'ll try to retrieve the token from the .netrc file instead.')
+      expect(unwrap(stderr.output)).to.contain('To turn off this warning, set HEROKU_KEYCHAIN_WARNINGS to "off".')
 
       stderr.stop()
     })
@@ -252,9 +252,9 @@ describe('credential-manager', function () {
       expect(macosStub.notCalled).to.be.true
       expect(netrcStub.calledOnce).to.be.true
       expect(token).to.equal('netrc-token')
-      expect(unwrap(stderr.output)).to.contain('Warning: Unable to retrieve Heroku token from heroku-cli.')
-      expect(unwrap(stderr.output)).to.contain('We will attempt to retrieve the token from the .netrc file instead.')
-      expect(unwrap(stderr.output)).to.contain('To turn off this warning in the future, set HEROKU_KEYCHAIN_WARNINGS to "off".')
+      expect(unwrap(stderr.output)).to.contain('Warning: We can’t retrieve the Heroku token from heroku-cli.')
+      expect(unwrap(stderr.output)).to.contain('We\'ll try to retrieve the token from the .netrc file instead.')
+      expect(unwrap(stderr.output)).to.contain('To turn off this warning, set HEROKU_KEYCHAIN_WARNINGS to "off".')
 
       stderr.stop()
     })
@@ -304,9 +304,9 @@ describe('credential-manager', function () {
 
       expect(macosStub.calledOnce).to.be.true
       expect(netrcStub.calledOnce).to.be.true
-      expect(unwrap(stderr.output)).to.contain('Warning: Unable to remove Heroku token from heroku-cli.')
-      expect(unwrap(stderr.output)).to.contain('Token will be removed from the .netrc file instead.')
-      expect(unwrap(stderr.output)).to.contain('To turn off this warning in the future, set HEROKU_KEYCHAIN_WARNINGS to "off".')
+      expect(unwrap(stderr.output)).to.contain('Warning: We can’t remove the Heroku token from heroku-cli.')
+      expect(unwrap(stderr.output)).to.contain('We\'ll remove the token from the .netrc file instead.')
+      expect(unwrap(stderr.output)).to.contain('To turn off this warning, set HEROKU_KEYCHAIN_WARNINGS to "off".')
 
       stderr.stop()
     })
@@ -383,9 +383,9 @@ describe('credential-manager', function () {
 
       expect(macosStub.notCalled).to.be.true
       expect(netrcStub.calledOnce).to.be.true
-      expect(unwrap(stderr.output)).to.contain('Warning: Unable to remove Heroku token from heroku-cli.')
-      expect(unwrap(stderr.output)).to.contain('Token will be removed from the .netrc file instead.')
-      expect(unwrap(stderr.output)).to.contain('To turn off this warning in the future, set HEROKU_KEYCHAIN_WARNINGS to "off".')
+      expect(unwrap(stderr.output)).to.contain('Warning: We can’t remove the Heroku token from heroku-cli.')
+      expect(unwrap(stderr.output)).to.contain('We\'ll remove the token from the .netrc file instead.')
+      expect(unwrap(stderr.output)).to.contain('To turn off this warning, set HEROKU_KEYCHAIN_WARNINGS to "off".')
 
       stderr.stop()
     })

--- a/test/credential-manager/index.test.ts
+++ b/test/credential-manager/index.test.ts
@@ -2,6 +2,7 @@ import {expect, use} from 'chai'
 import chaiAsPromised from 'chai-as-promised'
 import inquirer from 'inquirer'
 import sinon from 'sinon'
+import {stderr} from 'stdout-stderr'
 
 import {LinuxHandler} from '../../src/credential-manager-core/credential-handlers/linux-handler.js'
 import {MacOSHandler} from '../../src/credential-manager-core/credential-handlers/macos-handler.js'
@@ -9,6 +10,7 @@ import {NetrcHandler} from '../../src/credential-manager-core/credential-handler
 import {WindowsHandler} from '../../src/credential-manager-core/credential-handlers/windows-handler.js'
 import * as credentialManager from '../../src/credential-manager-core/index.js'
 import {CredentialStore} from '../../src/credential-manager-core/lib/credential-storage-selector.js'
+import {unwrap} from '../helpers/unwrap.js'
 
 use(chaiAsPromised)
 
@@ -63,10 +65,16 @@ describe('credential-manager', function () {
       const macosStub = sinon.stub(MacOSHandler.prototype, 'saveAuth').throws(new Error('Keychain error'))
       const netrcStub = sinon.stub(NetrcHandler.prototype, 'saveAuthForHosts').resolves()
 
+      stderr.start()
       await credentialManager.saveAuth('user@example.com', 'test-token', ['api.heroku.com'])
 
       expect(macosStub.calledOnce).to.be.true
       expect(netrcStub.calledOnce).to.be.true
+      expect(unwrap(stderr.output)).to.contain('Warning: Unable to save Heroku token to heroku-cli: Keychain error.')
+      expect(unwrap(stderr.output)).to.contain('Token will be saved to the .netrc file instead.')
+      expect(unwrap(stderr.output)).to.contain('To turn off this warning in the future, set HEROKU_KEYCHAIN_WARNINGS to "off".')
+
+      stderr.stop()
     })
 
     it('should save to credential store once and netrc once for multiple hosts', async function () {
@@ -85,7 +93,7 @@ describe('credential-manager', function () {
       const netrcStub = sinon.stub(NetrcHandler.prototype, 'saveAuthForHosts').throws(new Error('Netrc error'))
 
       await expect(credentialManager.saveAuth('user@example.com', 'test-token', ['api.heroku.com']))
-        .to.be.rejectedWith(Error, 'Netrc error')
+      .to.be.rejectedWith(Error, 'Netrc error')
       expect(macosStub.calledOnce).to.be.true
       expect(netrcStub.calledOnce).to.be.true
     })
@@ -136,12 +144,19 @@ describe('credential-manager', function () {
       const netrcStub = sinon.stub(NetrcHandler.prototype, 'getAuth')
       netrcStub.resolves({login: 'user@example.com', password: 'netrc-token'})
 
+      stderr.start()
+
       const token = await credentialManager.getAuth('user@example.com', 'api.heroku.com')
 
       expect(token).to.equal('netrc-token')
       expect(macosStub.calledOnce).to.be.true
       expect(netrcStub.calledOnce).to.be.true
       expect(netrcStub.firstCall.args[0]).to.equal('api.heroku.com')
+      expect(unwrap(stderr.output)).to.contain('Warning: Unable to retrieve Heroku token from heroku-cli: Keychain error.')
+      expect(unwrap(stderr.output)).to.contain('Token will be retrieved from the .netrc file instead.')
+      expect(unwrap(stderr.output)).to.contain('To turn off this warning in the future, set HEROKU_KEYCHAIN_WARNINGS to "off".')
+
+      stderr.stop()
     })
 
     it('should throw error when credentials are not found in either location', async function () {
@@ -149,10 +164,17 @@ describe('credential-manager', function () {
       const netrcStub = sinon.stub(NetrcHandler.prototype, 'getAuth')
       netrcStub.rejects(new Error('No auth found for api.heroku.com'))
 
+      stderr.start()
+
       await expect(credentialManager.getAuth('user@example.com', 'api.heroku.com'))
         .to.be.rejectedWith(Error, 'No auth found for api.heroku.com')
       expect(macosStub.calledOnce).to.be.true
       expect(netrcStub.calledOnce).to.be.true
+      expect(unwrap(stderr.output)).to.contain('Warning: Unable to retrieve Heroku token from heroku-cli: Not found.')
+      expect(unwrap(stderr.output)).to.contain('Token will be retrieved from the .netrc file instead.')
+      expect(unwrap(stderr.output)).to.contain('To turn off this warning in the future, set HEROKU_KEYCHAIN_WARNINGS to "off".')
+
+      stderr.stop()
     })
 
     it('should throw error when netrc password is empty', async function () {
@@ -160,10 +182,17 @@ describe('credential-manager', function () {
       const netrcStub = sinon.stub(NetrcHandler.prototype, 'getAuth')
       netrcStub.resolves({login: 'user@example.com', password: undefined})
 
+      stderr.start()
+
       await expect(credentialManager.getAuth('user@example.com', 'api.heroku.com'))
         .to.be.rejectedWith(Error, 'No credentials found. Please log in.')
       expect(macosStub.calledOnce).to.be.true
       expect(netrcStub.calledOnce).to.be.true
+      expect(unwrap(stderr.output)).to.contain('Warning: Unable to retrieve Heroku token from heroku-cli: Not found.')
+      expect(unwrap(stderr.output)).to.contain('Token will be retrieved from the .netrc file instead.')
+      expect(unwrap(stderr.output)).to.contain('To turn off this warning in the future, set HEROKU_KEYCHAIN_WARNINGS to "off".')
+
+      stderr.stop()
     })
 
     it('should use the selected account when an account is not provided', async function () {
@@ -216,11 +245,18 @@ describe('credential-manager', function () {
       const netrcStub = sinon.stub(NetrcHandler.prototype, 'getAuth')
       netrcStub.resolves({login: 'user@example.com', password: 'netrc-token'})
 
+      stderr.start()
+
       const token = await credentialManager.getAuth(undefined, 'api.heroku.com')
 
       expect(macosStub.notCalled).to.be.true
       expect(netrcStub.calledOnce).to.be.true
       expect(token).to.equal('netrc-token')
+      expect(unwrap(stderr.output)).to.contain('Warning: Unable to retrieve Heroku token from heroku-cli: Keychain error.')
+      expect(unwrap(stderr.output)).to.contain('Token will be retrieved from the .netrc file instead.')
+      expect(unwrap(stderr.output)).to.contain('To turn off this warning in the future, set HEROKU_KEYCHAIN_WARNINGS to "off".')
+
+      stderr.stop()
     })
 
     it('should retrieve from credential store with custom service name', async function () {
@@ -263,10 +299,16 @@ describe('credential-manager', function () {
       const macosStub = sinon.stub(MacOSHandler.prototype, 'removeAuth').throws(new Error('Keychain error'))
       const netrcStub = sinon.stub(NetrcHandler.prototype, 'removeAuthForHosts').resolves()
 
+      stderr.start()
       await credentialManager.removeAuth('user@example.com', ['api.heroku.com'])
 
       expect(macosStub.calledOnce).to.be.true
       expect(netrcStub.calledOnce).to.be.true
+      expect(unwrap(stderr.output)).to.contain('Warning: Unable to remove Heroku token from heroku-cli: Keychain error.')
+      expect(unwrap(stderr.output)).to.contain('Token will be removed from the .netrc file instead.')
+      expect(unwrap(stderr.output)).to.contain('To turn off this warning in the future, set HEROKU_KEYCHAIN_WARNINGS to "off".')
+
+      stderr.stop()
     })
 
     it('should remove from credential store once and netrc once for multiple hosts', async function () {
@@ -335,10 +377,17 @@ describe('credential-manager', function () {
       const macosStub = sinon.stub(MacOSHandler.prototype, 'removeAuth')
       const netrcStub = sinon.stub(NetrcHandler.prototype, 'removeAuthForHosts').resolves()
 
+      stderr.start()
+
       await credentialManager.removeAuth(undefined, ['api.heroku.com'])
 
       expect(macosStub.notCalled).to.be.true
       expect(netrcStub.calledOnce).to.be.true
+      expect(unwrap(stderr.output)).to.contain('Warning: Unable to remove Heroku token from heroku-cli: Keychain error.')
+      expect(unwrap(stderr.output)).to.contain('Token will be removed from the .netrc file instead.')
+      expect(unwrap(stderr.output)).to.contain('To turn off this warning in the future, set HEROKU_KEYCHAIN_WARNINGS to "off".')
+
+      stderr.stop()
     })
 
     it('should remove from credential store with custom service name', async function () {

--- a/test/credential-manager/index.test.ts
+++ b/test/credential-manager/index.test.ts
@@ -153,7 +153,7 @@ describe('credential-manager', function () {
       expect(netrcStub.calledOnce).to.be.true
       expect(netrcStub.firstCall.args[0]).to.equal('api.heroku.com')
       expect(unwrap(stderr.output)).to.contain('Warning: Unable to retrieve Heroku token from heroku-cli.')
-      expect(unwrap(stderr.output)).to.contain('Token will be retrieved from the .netrc file instead.')
+      expect(unwrap(stderr.output)).to.contain('We will attempt to retrieve the token from the .netrc file instead.')
       expect(unwrap(stderr.output)).to.contain('To turn off this warning in the future, set HEROKU_KEYCHAIN_WARNINGS to "off".')
 
       stderr.stop()
@@ -171,7 +171,7 @@ describe('credential-manager', function () {
       expect(macosStub.calledOnce).to.be.true
       expect(netrcStub.calledOnce).to.be.true
       expect(unwrap(stderr.output)).to.contain('Warning: Unable to retrieve Heroku token from heroku-cli.')
-      expect(unwrap(stderr.output)).to.contain('Token will be retrieved from the .netrc file instead.')
+      expect(unwrap(stderr.output)).to.contain('We will attempt to retrieve the token from the .netrc file instead.')
       expect(unwrap(stderr.output)).to.contain('To turn off this warning in the future, set HEROKU_KEYCHAIN_WARNINGS to "off".')
 
       stderr.stop()
@@ -189,7 +189,7 @@ describe('credential-manager', function () {
       expect(macosStub.calledOnce).to.be.true
       expect(netrcStub.calledOnce).to.be.true
       expect(unwrap(stderr.output)).to.contain('Warning: Unable to retrieve Heroku token from heroku-cli.')
-      expect(unwrap(stderr.output)).to.contain('Token will be retrieved from the .netrc file instead.')
+      expect(unwrap(stderr.output)).to.contain('We will attempt to retrieve the token from the .netrc file instead.')
       expect(unwrap(stderr.output)).to.contain('To turn off this warning in the future, set HEROKU_KEYCHAIN_WARNINGS to "off".')
 
       stderr.stop()
@@ -253,7 +253,7 @@ describe('credential-manager', function () {
       expect(netrcStub.calledOnce).to.be.true
       expect(token).to.equal('netrc-token')
       expect(unwrap(stderr.output)).to.contain('Warning: Unable to retrieve Heroku token from heroku-cli.')
-      expect(unwrap(stderr.output)).to.contain('Token will be retrieved from the .netrc file instead.')
+      expect(unwrap(stderr.output)).to.contain('We will attempt to retrieve the token from the .netrc file instead.')
       expect(unwrap(stderr.output)).to.contain('To turn off this warning in the future, set HEROKU_KEYCHAIN_WARNINGS to "off".')
 
       stderr.stop()

--- a/test/credential-manager/index.test.ts
+++ b/test/credential-manager/index.test.ts
@@ -70,7 +70,7 @@ describe('credential-manager', function () {
 
       expect(macosStub.calledOnce).to.be.true
       expect(netrcStub.calledOnce).to.be.true
-      expect(unwrap(stderr.output)).to.contain('Warning: Unable to save Heroku token to heroku-cli: Keychain error.')
+      expect(unwrap(stderr.output)).to.contain('Warning: Unable to save Heroku token to heroku-cli.')
       expect(unwrap(stderr.output)).to.contain('Token will be saved to the .netrc file instead.')
       expect(unwrap(stderr.output)).to.contain('To turn off this warning in the future, set HEROKU_KEYCHAIN_WARNINGS to "off".')
 
@@ -152,7 +152,7 @@ describe('credential-manager', function () {
       expect(macosStub.calledOnce).to.be.true
       expect(netrcStub.calledOnce).to.be.true
       expect(netrcStub.firstCall.args[0]).to.equal('api.heroku.com')
-      expect(unwrap(stderr.output)).to.contain('Warning: Unable to retrieve Heroku token from heroku-cli: Keychain error.')
+      expect(unwrap(stderr.output)).to.contain('Warning: Unable to retrieve Heroku token from heroku-cli.')
       expect(unwrap(stderr.output)).to.contain('Token will be retrieved from the .netrc file instead.')
       expect(unwrap(stderr.output)).to.contain('To turn off this warning in the future, set HEROKU_KEYCHAIN_WARNINGS to "off".')
 
@@ -170,7 +170,7 @@ describe('credential-manager', function () {
         .to.be.rejectedWith(Error, 'No auth found for api.heroku.com')
       expect(macosStub.calledOnce).to.be.true
       expect(netrcStub.calledOnce).to.be.true
-      expect(unwrap(stderr.output)).to.contain('Warning: Unable to retrieve Heroku token from heroku-cli: Not found.')
+      expect(unwrap(stderr.output)).to.contain('Warning: Unable to retrieve Heroku token from heroku-cli.')
       expect(unwrap(stderr.output)).to.contain('Token will be retrieved from the .netrc file instead.')
       expect(unwrap(stderr.output)).to.contain('To turn off this warning in the future, set HEROKU_KEYCHAIN_WARNINGS to "off".')
 
@@ -188,7 +188,7 @@ describe('credential-manager', function () {
         .to.be.rejectedWith(Error, 'No credentials found. Please log in.')
       expect(macosStub.calledOnce).to.be.true
       expect(netrcStub.calledOnce).to.be.true
-      expect(unwrap(stderr.output)).to.contain('Warning: Unable to retrieve Heroku token from heroku-cli: Not found.')
+      expect(unwrap(stderr.output)).to.contain('Warning: Unable to retrieve Heroku token from heroku-cli.')
       expect(unwrap(stderr.output)).to.contain('Token will be retrieved from the .netrc file instead.')
       expect(unwrap(stderr.output)).to.contain('To turn off this warning in the future, set HEROKU_KEYCHAIN_WARNINGS to "off".')
 
@@ -252,7 +252,7 @@ describe('credential-manager', function () {
       expect(macosStub.notCalled).to.be.true
       expect(netrcStub.calledOnce).to.be.true
       expect(token).to.equal('netrc-token')
-      expect(unwrap(stderr.output)).to.contain('Warning: Unable to retrieve Heroku token from heroku-cli: Keychain error.')
+      expect(unwrap(stderr.output)).to.contain('Warning: Unable to retrieve Heroku token from heroku-cli.')
       expect(unwrap(stderr.output)).to.contain('Token will be retrieved from the .netrc file instead.')
       expect(unwrap(stderr.output)).to.contain('To turn off this warning in the future, set HEROKU_KEYCHAIN_WARNINGS to "off".')
 
@@ -304,7 +304,7 @@ describe('credential-manager', function () {
 
       expect(macosStub.calledOnce).to.be.true
       expect(netrcStub.calledOnce).to.be.true
-      expect(unwrap(stderr.output)).to.contain('Warning: Unable to remove Heroku token from heroku-cli: Keychain error.')
+      expect(unwrap(stderr.output)).to.contain('Warning: Unable to remove Heroku token from heroku-cli.')
       expect(unwrap(stderr.output)).to.contain('Token will be removed from the .netrc file instead.')
       expect(unwrap(stderr.output)).to.contain('To turn off this warning in the future, set HEROKU_KEYCHAIN_WARNINGS to "off".')
 
@@ -383,7 +383,7 @@ describe('credential-manager', function () {
 
       expect(macosStub.notCalled).to.be.true
       expect(netrcStub.calledOnce).to.be.true
-      expect(unwrap(stderr.output)).to.contain('Warning: Unable to remove Heroku token from heroku-cli: Keychain error.')
+      expect(unwrap(stderr.output)).to.contain('Warning: Unable to remove Heroku token from heroku-cli.')
       expect(unwrap(stderr.output)).to.contain('Token will be removed from the .netrc file instead.')
       expect(unwrap(stderr.output)).to.contain('To turn off this warning in the future, set HEROKU_KEYCHAIN_WARNINGS to "off".')
 

--- a/test/helpers/unwrap.ts
+++ b/test/helpers/unwrap.ts
@@ -1,0 +1,8 @@
+const unwrap = function (str: string): string {
+  let sanitize = str.replace(/\n ([▸›»]) {3}/g, '')
+  sanitize = sanitize.replace(/ ([▸›»]) {3}/g, '')
+
+  return sanitize
+}
+
+export {unwrap}


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary
<!-- Brief description of the changes in this PR. -->
Adds warning messages that alert the user when the credential manager keychain tools fail that we will fall back to the .netrc file instead.

This PR also adds a unit test that tests that the .netrc is used for a fallback when the keychain tool fails. In order to make this happen, I had to add a few additional acceptance test helper functions (and unit/integration tests for those helper functions) that force the appropriate keychain tool to fail.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [x] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**: 
<!-- Add any context/setup necessary for testing. -->

**Steps**:
1. Passing CI suffices.

## Screenshots (if applicable)

## Related Issues
GUS work item: [W-21816804](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002XCCOlYAP/view)
