### PR TITLE
fix: clear native store on logout regarless of HEROKU_NETRC_WRITE

### DIFF
--- a/src/credential-manager-core/index.ts
+++ b/src/credential-manager-core/index.ts
@@ -8,7 +8,7 @@ import {NetrcHandler} from './credential-handlers/netrc-handler.js'
 import {WindowsHandler} from './credential-handlers/windows-handler.js'
 import {selectAccount} from './lib/account-selector.js'
 import {reportCredentialStoreError} from './lib/cli-command-telemetry.js'
-import {CredentialStore, getStorageConfig} from './lib/credential-storage-selector.js'
+import {CredentialStore, getNativeCredentialStore, getStorageConfig} from './lib/credential-storage-selector.js'
 import {NetrcAuthEntry} from './lib/types.js'
 
 const credDebug = debug('heroku-credential-manager')
@@ -119,7 +119,8 @@ export async function getAuth(account: string | undefined, host: string, service
 }
 
 /**
- * Removes authentication credentials from the native credential store (if available) and .netrc file.
+ * Removes authentication credentials from the platform native store (when present) and .netrc.
+ * Uses {@link getNativeCredentialStore} so HEROKU_NETRC_WRITE does not skip Keychain/vault cleanup after a mixed login.
  *
  * @param account - User's account (email), or undefined to search for account
  * @param hosts - Hostname(s) for netrc storage (e.g., ['api.heroku.com'])
@@ -129,10 +130,11 @@ export async function getAuth(account: string | undefined, host: string, service
 export async function removeAuth(account: string | undefined, hosts: string[], service = SERVICE_NAME): Promise<void> {
   const config = getStorageConfig()
   const netrcHandler = new NetrcHandler()
+  const nativeStore = getNativeCredentialStore()
 
-  if (config.credentialStore) {
+  if (nativeStore) {
     try {
-      const handler = getCredentialHandler(config.credentialStore)
+      const handler = getCredentialHandler(nativeStore)
 
       if (account) {
         handler.removeAuth(account, service)
@@ -157,7 +159,7 @@ export async function removeAuth(account: string | undefined, hosts: string[], s
       }
 
       await reportCredentialStoreError(error, {
-        credentialStore: config.credentialStore,
+        credentialStore: nativeStore,
         operation: 'removeAuth',
       })
     }
@@ -195,7 +197,7 @@ export {MacOSHandler} from './credential-handlers/macos-handler.js'
 export {NetrcHandler} from './credential-handlers/netrc-handler.js'
 export {WindowsHandler} from './credential-handlers/windows-handler.js'
 export {selectAccount} from './lib/account-selector.js'
-export {CredentialStore, getStorageConfig} from './lib/credential-storage-selector.js'
+export {CredentialStore, getNativeCredentialStore, getStorageConfig} from './lib/credential-storage-selector.js'
 export type {StorageConfig} from './lib/credential-storage-selector.js'
 export {Netrc, parse} from './lib/netrc-parser.js'
 export type {

--- a/src/credential-manager-core/lib/credential-storage-selector.ts
+++ b/src/credential-manager-core/lib/credential-storage-selector.ts
@@ -82,6 +82,32 @@ export function getStorageConfig(): StorageConfig {
 }
 
 /**
+ * Native credential backend for this platform (Keychain, Secret Service, Windows vault).
+ * Ignores HEROKU_NETRC_WRITE so logout can clear credentials written before that mode was used.
+ */
+export function getNativeCredentialStore(): CredentialStore | null {
+  const {platform} = process
+
+  switch (platform) {
+  case 'darwin': {
+    return CredentialStore.MacOSKeychain
+  }
+
+  case 'linux': {
+    return hasSecretTool() ? CredentialStore.LinuxSecretService : null
+  }
+
+  case 'win32': {
+    return CredentialStore.WindowsCredentialManager
+  }
+
+  default: {
+    return null
+  }
+  }
+}
+
+/**
  * Determines whether the secret-tool command is accessible.
  *
  * @returns True if secret-tool is installed and accessible, false otherwise

--- a/src/credential-manager-core/lib/credential-storage-selector.ts
+++ b/src/credential-manager-core/lib/credential-storage-selector.ts
@@ -14,70 +14,18 @@ export type StorageConfig = {
 }
 
 /**
- * Determines whether to use OS-native credential storage, .netrc file, or both.
+ * Determines whether the secret-tool command is accessible.
  *
- * @returns Object containing storage configuration
- *
- * @example
- * ```typescript
- * const config = getStorageConfig()
- * if (config.credentialStore === CredentialStore.MacOSKeychain) {
- *   // Use macOS handler
- * }
- * if (config.useNetrc) {
- *   // Also use netrc handler
- * }
- * ```
+ * @returns True if secret-tool is installed and accessible, false otherwise
  */
-export function getStorageConfig(): StorageConfig {
-  const {env, platform} = process
-  const {HEROKU_NETRC_WRITE} = env
-
-  // Forces the use of the .netrc file only
-  if (HEROKU_NETRC_WRITE?.toLowerCase() === 'true') {
-    return {
-      credentialStore: null,
-      useNetrc: true,
-    }
-  }
-
-  switch (platform) {
-  case 'darwin': {
-    return {
-      credentialStore: CredentialStore.MacOSKeychain,
-      useNetrc: true,
-    }
-  }
-
-  case 'linux': {
-    if (hasSecretTool()) {
-      return {
-        credentialStore: CredentialStore.LinuxSecretService,
-        useNetrc: true,
-      }
-    }
-
-    // secret-tool not accessible, fall back to netrc only
-    return {
-      credentialStore: null,
-      useNetrc: true,
-    }
-  }
-
-  case 'win32': {
-    return {
-      credentialStore: CredentialStore.WindowsCredentialManager,
-      useNetrc: true,
-    }
-  }
-
-  default: {
-    // Unsupported platform, fall back to netrc only
-    return {
-      credentialStore: null,
-      useNetrc: true,
-    }
-  }
+function hasSecretTool(): boolean {
+  try {
+    childProcess.execSync('which secret-tool', {
+      stdio: 'ignore',
+    })
+    return true
+  } catch {
+    return false
   }
 }
 
@@ -108,17 +56,31 @@ export function getNativeCredentialStore(): CredentialStore | null {
 }
 
 /**
- * Determines whether the secret-tool command is accessible.
+ * Determines whether to use OS-native credential storage, .netrc file, or both.
  *
- * @returns True if secret-tool is installed and accessible, false otherwise
+ * @returns Object containing storage configuration
+ *
+ * @example
+ * ```typescript
+ * const config = getStorageConfig()
+ * if (config.credentialStore === CredentialStore.MacOSKeychain) {
+ *   // Use macOS handler
+ * }
+ * if (config.useNetrc) {
+ *   // Also use netrc handler
+ * }
+ * ```
  */
-function hasSecretTool(): boolean {
-  try {
-    childProcess.execSync('which secret-tool', {
-      stdio: 'ignore',
-    })
-    return true
-  } catch {
-    return false
+export function getStorageConfig(): StorageConfig {
+  if (process.env.HEROKU_NETRC_WRITE?.toLowerCase() === 'true') {
+    return {
+      credentialStore: null,
+      useNetrc: true,
+    }
+  }
+
+  return {
+    credentialStore: getNativeCredentialStore(),
+    useNetrc: true,
   }
 }

--- a/test/credential-manager/acceptance/index.acceptance.test.ts
+++ b/test/credential-manager/acceptance/index.acceptance.test.ts
@@ -199,6 +199,18 @@ describe('credential-manager acceptance', function () {
       .to.be.rejectedWith(/No auth found|No credentials found/)
     })
 
+    it('removes native store when logout runs with HEROKU_NETRC_WRITE after dual-path login', async function () {
+      delete process.env.HEROKU_NETRC_WRITE
+      await saveAuth(CREDENTIAL.account, CREDENTIAL.token, CREDENTIAL.hosts, CREDENTIAL.service)
+
+      process.env.HEROKU_NETRC_WRITE = 'TRUE'
+      await removeAuth(CREDENTIAL.account, CREDENTIAL.hosts, CREDENTIAL.service)
+      delete process.env.HEROKU_NETRC_WRITE
+
+      await expect(getAuth(CREDENTIAL.account, CREDENTIAL.hosts[0], CREDENTIAL.service))
+      .to.be.rejectedWith(/No auth found|No credentials found/)
+    })
+
     it('saves to netrc when credential store fails', async function () {
       // Set up fake credential store command for the current platform
       const fakeSetup = setupFakeCredentialStore()

--- a/test/credential-manager/index.test.ts
+++ b/test/credential-manager/index.test.ts
@@ -284,14 +284,14 @@ describe('credential-manager', function () {
       expect(netrcStub.firstCall.args[0]).to.deep.equal(['api.heroku.com'])
     })
 
-    it('should remove from netrc-only when credential store is disabled', async function () {
+    it('should still remove from native store when HEROKU_NETRC_WRITE disables save path', async function () {
       process.env.HEROKU_NETRC_WRITE = 'TRUE'
       const macosStub = sinon.stub(MacOSHandler.prototype, 'removeAuth')
       const netrcStub = sinon.stub(NetrcHandler.prototype, 'removeAuthForHosts').resolves()
 
       await credentialManager.removeAuth('user@example.com', ['api.heroku.com'])
 
-      expect(macosStub.notCalled).to.be.true
+      expect(macosStub.calledOnce).to.be.true
       expect(netrcStub.calledOnce).to.be.true
     })
 

--- a/test/credential-manager/lib/credential-storage-selector.test.ts
+++ b/test/credential-manager/lib/credential-storage-selector.test.ts
@@ -2,7 +2,7 @@ import {expect} from 'chai'
 import childProcess from 'node:child_process'
 import sinon from 'sinon'
 
-import {CredentialStore, getStorageConfig} from '../../../src/credential-manager-core/lib/credential-storage-selector.js'
+import {CredentialStore, getNativeCredentialStore, getStorageConfig} from '../../../src/credential-manager-core/lib/credential-storage-selector.js'
 
 describe('credential-storage-selector', function () {
   describe('getStorageConfig', function () {
@@ -78,6 +78,58 @@ describe('credential-storage-selector', function () {
 
       expect(result.credentialStore).to.be.null
       expect(result.useNetrc).to.be.true
+    })
+  })
+
+  describe('getNativeCredentialStore', function () {
+    let platformStub: sinon.SinonStub
+
+    beforeEach(function () {
+      platformStub = sinon.stub(process, 'platform')
+      const env = {...process.env}
+      sinon.stub(process, 'env').value(env)
+      delete env.HEROKU_NETRC_WRITE
+    })
+
+    afterEach(function () {
+      sinon.restore()
+    })
+
+    it('returns macOS Keychain on darwin even when HEROKU_NETRC_WRITE is true', function () {
+      platformStub.value('darwin')
+      process.env.HEROKU_NETRC_WRITE = 'TRUE'
+
+      expect(getNativeCredentialStore()).to.equal(CredentialStore.MacOSKeychain)
+      expect(getStorageConfig().credentialStore).to.be.null
+    })
+
+    it('returns Windows store on win32 regardless of HEROKU_NETRC_WRITE', function () {
+      platformStub.value('win32')
+      process.env.HEROKU_NETRC_WRITE = 'TRUE'
+
+      expect(getNativeCredentialStore()).to.equal(CredentialStore.WindowsCredentialManager)
+    })
+
+    it('returns Linux Secret Service when secret-tool exists', function () {
+      platformStub.value('linux')
+      const execSyncStub = sinon.stub(childProcess, 'execSync')
+      execSyncStub.returns(Buffer.from('/usr/bin/secret-tool\n'))
+
+      expect(getNativeCredentialStore()).to.equal(CredentialStore.LinuxSecretService)
+    })
+
+    it('returns null on linux when secret-tool is missing', function () {
+      platformStub.value('linux')
+      const execSyncStub = sinon.stub(childProcess, 'execSync')
+      execSyncStub.throws(new Error('secret-tool not found'))
+
+      expect(getNativeCredentialStore()).to.be.null
+    })
+
+    it('returns null on unsupported platforms', function () {
+      platformStub.value('freebsd')
+
+      expect(getNativeCredentialStore()).to.be.null
     })
   })
 })


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary
<!-- Brief description of the changes in this PR. -->
This fixes logout scenario where when credentials are logged in to native store and netrc, and the path for logout only through netrc is chosen, we ensure credentials are removed from both. 

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [x] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
logout with `heroku logout`
```
HEROKU_NETRC_WRITE=false DEBUG=heroku-credential-manager ./examples/run.sh login
HEROKU_NETRC_WRITE=true DEBUG=heroku-credential-manager ./examples/run.sh login
HEROKU_NETRC_WRITE=true DEBUG=heroku-credential-manager ./examples/run.sh logout
heroku apps
```
heroku apps should initiate a login and should not return resources. 

## Screenshots (if applicable)

## Related Issues
GitHub issue: #[GitHub issue number]
GUS work item: [W-21817743](https://gus.lightning.force.com/a07EE00002XCDfrYAH)
