### PR TITLE
fix: silence redundant console.error on netrc logout

### DIFF
--- a/src/credential-manager-core/credential-handlers/netrc-handler.ts
+++ b/src/credential-manager-core/credential-handlers/netrc-handler.ts
@@ -47,7 +47,6 @@ export class NetrcHandler {
     for (const host of hosts) {
       if (!this.netrc.machines[host]) {
         credDebug(`No credentials to logout for ${host}`)
-        console.error(`No credentials to logout for ${host}`)
         continue
       }
 


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary
<!-- Brief description of the changes in this PR. -->
This PR removes a `console.error` call in `NetrcHandler` when logging out and a host has no stored netrc credentials. The same condition is already logged via `credDebug`, so the extra `console.error` duplicates noise on `stderr`.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [x] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**: 
<!-- Add any context/setup necessary for testing. -->

**Steps**:
1. Passing CI suffices.

## Screenshots (if applicable)

## Related Issues
GUS work item: [W-20826509](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002SW4p9YAD/view)
