### PR TITLE
fix: throw an error when account is not resolved

### DIFF
--- a/src/credential-manager-core/index.ts
+++ b/src/credential-manager-core/index.ts
@@ -89,7 +89,7 @@ export async function getAuth(account: string | undefined, host: string, service
         return {account: selectedAccount, token}
       }
 
-      config.useNetrc = true
+      throw new Error('No auth found')
     } catch (error) {
       const {message} = error as Error
       credDebug(message)
@@ -111,13 +111,13 @@ export async function getAuth(account: string | undefined, host: string, service
     const auth = await netrcHandler.getAuth(host)
 
     if (!auth.password) {
-      throw new Error('No credentials found. Please log in.')
+      throw new Error('No auth found')
     }
 
     return {account: auth.login, token: auth.password}
   }
 
-  throw new Error('No credentials found. Please log in.')
+  throw new Error('No auth found')
 }
 
 /**

--- a/test/api-client.test.ts
+++ b/test/api-client.test.ts
@@ -111,7 +111,7 @@ describe('api_client', () => {
         setCredentialManagerProvider({
           async getAuth() {
             getCalls++
-            throw new Error('No credentials found. Please log in.')
+            throw new Error('No auth found')
           },
           async removeAuth() {},
           async saveAuth() {},
@@ -219,7 +219,7 @@ describe('api_client', () => {
       .it('clears token and account when called with undefined', async ctx => {
         setCredentialManagerProvider({
           async getAuth() {
-            throw new Error('No credentials found. Please log in.')
+            throw new Error('No auth found')
           },
           async removeAuth() {},
           async saveAuth() {},

--- a/test/credential-manager/index.test.ts
+++ b/test/credential-manager/index.test.ts
@@ -185,7 +185,7 @@ describe('credential-manager', function () {
       stderr.start()
 
       await expect(credentialManager.getAuth('user@example.com', 'api.heroku.com'))
-        .to.be.rejectedWith(Error, 'No credentials found. Please log in.')
+        .to.be.rejectedWith(Error, 'No auth found')
       expect(macosStub.calledOnce).to.be.true
       expect(netrcStub.calledOnce).to.be.true
       expect(unwrap(stderr.output)).to.contain('Warning: We can’t retrieve the Heroku token from heroku-cli.')
@@ -230,11 +230,18 @@ describe('credential-manager', function () {
       const netrcStub = sinon.stub(NetrcHandler.prototype, 'getAuth')
       netrcStub.resolves({login: 'user@example.com', password: 'netrc-token'})
 
+      stderr.start()
+
       const auth = await credentialManager.getAuth(undefined, 'api.heroku.com')
 
       expect(macosStub.notCalled).to.be.true
       expect(netrcStub.calledOnce).to.be.true
       expect(auth).to.deep.equal({account: 'user@example.com', token: 'netrc-token'})
+      expect(unwrap(stderr.output)).to.contain('Warning: We can’t retrieve the Heroku token from heroku-cli.')
+      expect(unwrap(stderr.output)).to.contain('We\'ll try to retrieve the token from the .netrc file instead.')
+      expect(unwrap(stderr.output)).to.contain('To turn off this warning, set HEROKU_KEYCHAIN_WARNINGS to "off".')
+
+      stderr.stop()
     })
 
     it('should fall back to netrc when an account is not provided and listAccounts fails', async function () {

--- a/test/helpers/credential-manager-stub.ts
+++ b/test/helpers/credential-manager-stub.ts
@@ -20,7 +20,7 @@ export function stubCredentialManager(token = DEFAULT_TOKEN) {
 export function stubCredentialManagerWithNoCredentials() {
   setCredentialManagerProvider({
     async getAuth() {
-      throw new Error('No credentials found. Please log in.')
+      throw new Error('No auth found')
     },
     async removeAuth() {},
     async saveAuth() {},


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary
<!-- Brief description of the changes in this PR. -->
This PR updates `getAuth` to throw an error when the keychain path does not resolve an account, so the failure can be reported to Sentry. It also standardizes missing-credential errors to `No auth found` and updates tests/stubs.

**Note:** `config.useNetrc = true` was redundant, since `useNetrc` is already `true` from `getStorageConfig()` in default configurations. Although it was removed, the fallback to netrc still happens.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [x] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**: 
<!-- Add any context/setup necessary for testing. -->

**Steps**:
1. Passing CI suffices

## Screenshots (if applicable)

## Related Issues
GUS work item: [W-22068747](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002YInsuYAD/view)
