### PR TITLE
fix: stop removeauth error no acct

### DIFF
--- a/src/credential-manager-core/credential-handlers/linux-handler.ts
+++ b/src/credential-manager-core/credential-handlers/linux-handler.ts
@@ -100,7 +100,7 @@ export class LinuxHandler {
     const spawnResult = childProcess.spawnSync(
       'secret-tool',
       ['clear', 'service', service, 'account', account],
-      {encoding: 'utf8'},
+      {encoding: 'utf8', env: {...process.env, LC_ALL: 'C'}},
     )
 
     if (spawnResult.error) {
@@ -167,6 +167,11 @@ export class LinuxHandler {
   private isMissingSecretClearFailure(status: number, stderr: string): boolean {
     if (status === 0) {
       return false
+    }
+
+    // secret-tool clear exits 1 with no output when nothing matched (locale-independent).
+    if (status === 1 && stderr.trim() === '') {
+      return true
     }
 
     const text = stderr.toLowerCase()

--- a/src/credential-manager-core/credential-handlers/linux-handler.ts
+++ b/src/credential-manager-core/credential-handlers/linux-handler.ts
@@ -63,17 +63,11 @@ export class LinuxHandler {
         throw new Error(stderr)
       }
 
-      /** Expected output format:
-        stdout:
-          label = Label Name
-          secret = secret-value
-          created = 2024-01-01 12:00:00
-          modified = 2024-01-01 12:00:00
-          schema = org.freedesktop.Secret.Generic
-        stderr:
-          attribute.service = heroku-cli
-          attribute.account = user@example.com
-      */
+      /*
+       * Expected output format:
+       * stdout: label, secret, created, modified, schema lines
+       * stderr: attribute.service / attribute.account lines
+       */
 
       const accounts: string[] = []
       const lines = (spawnResult.stderr ?? '').split('\n')
@@ -103,15 +97,29 @@ export class LinuxHandler {
    * @throws Error if the removal operation fails.
    */
   public removeAuth(account: string, service: string): void {
-    try {
-      childProcess.execSync(
-        `secret-tool clear service "${service}" account "${account}"`,
-        {encoding: 'utf8'},
-      )
-    } catch (error) {
-      const {message} = error as Error
+    const spawnResult = childProcess.spawnSync(
+      'secret-tool',
+      ['clear', 'service', service, 'account', account],
+      {encoding: 'utf8'},
+    )
+
+    if (spawnResult.error) {
+      const {message} = spawnResult.error
       throw new Error(`Failed to remove token from Linux keyring: ${this.scrubError(message)}`)
     }
+
+    if (spawnResult.status === 0) {
+      return
+    }
+
+    const status = spawnResult.status ?? -1
+
+    const stderr = (spawnResult.stderr ?? '').toString()
+    if (this.isMissingSecretClearFailure(status, stderr)) {
+      return
+    }
+
+    throw new Error(`Failed to remove token from Linux keyring: ${this.scrubError(stderr || `exit ${status}`)}`)
   }
 
   /**
@@ -151,6 +159,18 @@ export class LinuxHandler {
       const {message} = error as Error
       throw new Error(`Failed to store token in Linux keyring: ${this.scrubError(message)}`)
     }
+  }
+
+  /**
+   * secret-tool clear fails when no matching credential exists; treat as successful no-op for logout.
+   */
+  private isMissingSecretClearFailure(status: number, stderr: string): boolean {
+    if (status === 0) {
+      return false
+    }
+
+    const text = stderr.toLowerCase()
+    return /no matching|could not find|not found|unknown attribute|does not exist|cannot remove/i.test(text)
   }
 
   /**

--- a/src/credential-manager-core/credential-handlers/macos-handler.ts
+++ b/src/credential-manager-core/credential-handlers/macos-handler.ts
@@ -114,6 +114,12 @@ export class MacOSHandler {
         },
       )
     } catch (error) {
+      const execError = error as Error & {status?: number}
+      // security exits 44 when the generic password does not exist (e.g. netrc-only login)
+      if (execError.status === 44) {
+        return
+      }
+
       const {message} = error as Error
       throw new Error(`Failed to remove token from macOS Keychain: ${this.scrubError(message)}`)
     }

--- a/src/credential-manager-core/credential-handlers/windows-handler.ts
+++ b/src/credential-manager-core/credential-handlers/windows-handler.ts
@@ -105,6 +105,10 @@ export class WindowsHandler {
       childProcess.execSync(psCommand, {encoding: 'utf8', shell: 'powershell', stdio: ['pipe', 'pipe', 'ignore']})
     } catch (error) {
       const {message} = error as Error
+      if (this.isMissingVaultCredential(message)) {
+        return
+      }
+
       throw new Error(`Failed to remove token from Windows Credential Manager: ${this.scrubError(message)}`)
     }
   }
@@ -143,6 +147,16 @@ export class WindowsHandler {
       const {message} = error as Error
       throw new Error(`Failed to store token in Windows Credential Manager: ${this.scrubError(message)}`)
     }
+  }
+
+  /**
+   * PasswordVault.Retrieve throws when the credential is absent (e.g. netrc-only login).
+   */
+  private isMissingVaultCredential(message: string): boolean {
+    const lower = message.toLowerCase()
+    return lower.includes('element not found')
+      || lower.includes('specified credential could not be found')
+      || lower.includes('0x80070490')
   }
 
   /**

--- a/src/credential-manager-core/index.ts
+++ b/src/credential-manager-core/index.ts
@@ -124,7 +124,7 @@ export async function getAuth(account: string | undefined, host: string, service
  * Removes authentication credentials from the platform native store (when present) and .netrc.
  * Uses {@link getNativeCredentialStore} so legacy HEROKU_NETRC_WRITE-only mode does not skip Keychain/vault cleanup after a mixed login.
  *
- * @param account - User's account (email)
+ * @param account - User's account (email), or undefined when using HEROKU_API_KEY only (native removal is skipped)
  * @param hosts - Hostname(s) for netrc storage (e.g., ['api.heroku.com'])
  * @param service - Service name (defaults to 'heroku-cli')
  * @returns Promise that resolves when credentials are removed
@@ -134,14 +134,9 @@ export async function removeAuth(account: string | undefined, hosts: string[], s
   const netrcHandler = new NetrcHandler()
   const nativeStore = getNativeCredentialStore()
 
-  if (nativeStore) {
+  if (nativeStore && account) {
     try {
       const handler = getCredentialHandler(nativeStore)
-
-      if (!account) {
-        throw new Error('Undefined account provided for removal')
-      }
-
       handler.removeAuth(account, service)
     } catch (error) {
       const {message} = error as Error

--- a/test/api-client.test.ts
+++ b/test/api-client.test.ts
@@ -271,6 +271,10 @@ describe('api_client', () => {
       api.get('/oauth/authorizations/~').reply(200, {})
     })
 
+    afterEach(() => {
+      delete process.env.HEROKU_API_KEY
+    })
+
     test
       .it('calls removeAuth with api and git hosts after revoking session', async ctx => {
         const cmd = new Command([], ctx.config)
@@ -280,6 +284,18 @@ describe('api_client', () => {
         expect(removeAuthCalls[0].account).to.equal('logout@example.com')
         expect(removeAuthCalls[0].hosts).to.deep.equal(['api.heroku.com', 'git.heroku.com'])
         expect(cmd.heroku.auth).to.be.undefined
+      })
+
+    test
+      .it('calls removeAuth with undefined account when HEROKU_API_KEY is set', async ctx => {
+        process.env.HEROKU_API_KEY = 'env-api-key'
+        removeAuthCalls.length = 0
+        const cmd = new Command([], ctx.config)
+        cmd.config = ctx.config
+        await cmd.heroku.logout()
+        expect(removeAuthCalls).to.have.length(1)
+        expect(removeAuthCalls[0].account).to.be.undefined
+        expect(removeAuthCalls[0].hosts).to.deep.equal(['api.heroku.com', 'git.heroku.com'])
       })
   })
 

--- a/test/credential-manager/credential-handlers/linux-handler.test.ts
+++ b/test/credential-manager/credential-handlers/linux-handler.test.ts
@@ -177,6 +177,35 @@ attribute.service = heroku-cli
         expect((error as Error).message).to.not.include('user@example.com')
       }
     })
+
+    it('should return when secret-tool exits 1 with empty stderr', function () {
+      spawnSyncStub.returns({
+        error: undefined,
+        status: 1,
+        stderr: '',
+      })
+      expect(() => handler.removeAuth('missing@example.com', 'heroku-cli')).to.not.throw()
+    })
+
+    it('should return when secret-tool exits 1 with whitespace-only stderr', function () {
+      spawnSyncStub.returns({
+        error: undefined,
+        status: 1,
+        stderr: '  \n',
+      })
+      expect(() => handler.removeAuth('missing@example.com', 'heroku-cli')).to.not.throw()
+    })
+
+    it('should pass LC_ALL=C in the environment', function () {
+      spawnSyncStub.returns({
+        error: undefined,
+        status: 0,
+        stderr: '',
+      })
+      handler.removeAuth('test@example.com', 'heroku-cli')
+      const options = spawnSyncStub.args[0][2]
+      expect(options.env.LC_ALL).to.equal('C')
+    })
   })
 
   describe('saveAuth', function () {

--- a/test/credential-manager/credential-handlers/linux-handler.test.ts
+++ b/test/credential-manager/credential-handlers/linux-handler.test.ts
@@ -130,20 +130,42 @@ attribute.service = heroku-cli
   })
 
   describe('removeAuth', function () {
-    it('should call execSync with the correct arguments to remove the token', function () {
-      execSyncStub.returns('')
+    it('should call spawnSync with the correct arguments to remove the token', function () {
+      spawnSyncStub.returns({
+        error: undefined,
+        status: 0,
+        stderr: '',
+      })
       handler.removeAuth('test@example.com', 'heroku-cli')
-      expect(execSyncStub.args[0][0]).to.contain('secret-tool clear service "heroku-cli" account "test@example.com"')
+      expect(spawnSyncStub.calledOnce).to.be.true
+      expect(spawnSyncStub.args[0][0]).to.equal('secret-tool')
+      expect(spawnSyncStub.args[0][1]).to.deep.equal(['clear', 'service', 'heroku-cli', 'account', 'test@example.com'])
     })
 
     it('should throw an error when removal fails', function () {
-      execSyncStub.throws(new Error('Permission denied'))
+      spawnSyncStub.returns({
+        error: undefined,
+        status: 1,
+        stderr: 'Permission denied',
+      })
       expect(() => handler.removeAuth('test@example.com', 'heroku-cli')).to.throw('Failed to remove token from Linux keyring: Permission denied')
     })
 
+    it('should return when no matching credential exists', function () {
+      spawnSyncStub.returns({
+        error: undefined,
+        status: 1,
+        stderr: 'No matching credentials\n',
+      })
+      expect(() => handler.removeAuth('missing@example.com', 'heroku-cli')).to.not.throw()
+    })
+
     it('should scrub sensitive data from error messages', function () {
-      const err = new Error('Command failed: secret-tool clear service "heroku-cli" account "user@example.com"')
-      execSyncStub.throws(err)
+      spawnSyncStub.returns({
+        error: undefined,
+        status: 1,
+        stderr: 'secret-tool clear service "heroku-cli" account "user@example.com" failed',
+      })
 
       try {
         handler.removeAuth('user@example.com', 'heroku-cli')

--- a/test/credential-manager/credential-handlers/macos-handler.test.ts
+++ b/test/credential-manager/credential-handlers/macos-handler.test.ts
@@ -165,6 +165,13 @@ attributes:
       expect(() => handler.removeAuth('test@example.com', 'heroku-cli')).to.throw('Failed to remove token from macOS Keychain: Permission denied')
     })
 
+    it('should return when the generic password does not exist (exit 44)', function () {
+      const err = new Error('Command failed') as Error & {status?: number}
+      err.status = 44
+      execSyncStub.throws(err)
+      expect(() => handler.removeAuth('missing@example.com', 'heroku-cli')).to.not.throw()
+    })
+
     it('should scrub sensitive data from error messages', function () {
       const err = new Error('Command failed: security delete-generic-password -a "user@example.com" -s "heroku-cli"')
       execSyncStub.throws(err)

--- a/test/credential-manager/credential-handlers/windows-handler.test.ts
+++ b/test/credential-manager/credential-handlers/windows-handler.test.ts
@@ -105,6 +105,11 @@ user2@example.com
       expect(() => handler.removeAuth('test@example.com', 'heroku-cli')).to.throw('Failed to remove token from Windows Credential Manager: Permission denied')
     })
 
+    it('should return when the credential does not exist', function () {
+      execSyncStub.throws(new Error('Element not found'))
+      expect(() => handler.removeAuth('missing@example.com', 'heroku-cli')).to.not.throw()
+    })
+
     it('should scrub sensitive data from error messages', function () {
       const err = new Error('Command failed: $vault.Retrieve("heroku-cli", "test@example.com")')
       execSyncStub.throws(err)

--- a/test/credential-manager/index.test.ts
+++ b/test/credential-manager/index.test.ts
@@ -419,7 +419,7 @@ describe('credential-manager', function () {
       expect(macosStub.args[0][1]).to.equal('custom-service')
     })
 
-    it('should continue to netrc if account is undefined', async function () {
+    it('should continue to netrc if account is undefined without native removal or warnings', async function () {
       const macosStub = sinon.stub(MacOSHandler.prototype, 'removeAuth')
       const netrcStub = sinon.stub(NetrcHandler.prototype, 'removeAuthForHosts').resolves()
 
@@ -428,9 +428,7 @@ describe('credential-manager', function () {
 
       expect(macosStub.notCalled).to.be.true
       expect(netrcStub.calledOnce).to.be.true
-      expect(unwrap(stderr.output)).to.contain('Warning: We can’t remove the Heroku token from heroku-cli.')
-      expect(unwrap(stderr.output)).to.contain('We\'ll remove the token from the .netrc file instead.')
-      expect(unwrap(stderr.output)).to.contain('To turn off this warning, set HEROKU_KEYCHAIN_WARNINGS to "off".')
+      expect(unwrap(stderr.output)).to.not.contain('We can’t remove the Heroku token from heroku-cli.')
 
       stderr.stop()
     })


### PR DESCRIPTION
## Summary

Stops treating expected logout cases as native-credential failures: when `HEROKU_API_KEY` is set there is no account email to target in the OS store, and when the vault/keychain has no matching entry, delete is a no-op. That removes spurious CLI warnings and Sentry reports while still clearing `.netrc` when configured.

- **Fix** `removeAuth` to skip native removal when `account` is undefined and only run netrc cleanup
- **Fix** macOS, Linux, and Windows handlers to treat “credential missing” on delete as a successful no-op (e.g. keychain exit 44, `secret-tool` / PasswordVault not-found)
- **Add** API client and credential-manager tests for `HEROKU_API_KEY` logout and undefined-account removal
- **Add** handler unit tests for missing-credential delete paths
- **Update** JSDoc for `removeAuth`’s `account` parameter

## Type of Change

- [x] **fix**: Bug fix or issue (patch semvar update)
- [ ] **feat**: Introduces a new feature to the codebase (minor semvar update)
- [ ] **perf**: Performance improvement
- [ ] **docs**: Documentation only changes
- [ ] **tests**: Adding missing tests or correcting existing tests
- [ ] **chore**: Code cleanup tasks, dependency updates, or other changes

## Verification

```bash
npm ci
npm run build
npm test
```

**Scenario A — `HEROKU_API_KEY` (no spurious keychain warning / no “Undefined account” in debug):**

```bash
unset HEROKU_NETRC_WRITE HEROKU_NATIVE_STORE_WRITE
export HEROKU_API_KEY=fake-invalid-token

DEBUG=heroku-credential-manager ./examples/run.sh logout
```

Expect: **no** “We can’t remove the Heroku token…” warning and **no** debug line `Undefined account provided for removal`.

**Scenario B — netrc-only login, optional keychain hygiene (quiet when vault never had an entry):**

```bash
unset HEROKU_API_KEY HEROKU_NATIVE_STORE_WRITE

HEROKU_NETRC_WRITE=true DEBUG=heroku-credential-manager ./examples/run.sh login
HEROKU_NETRC_WRITE=true DEBUG=heroku-credential-manager ./examples/run.sh logout

cat ~/.netrc
```

(Confirm behavior matches your environment: quiet logout when native store had nothing to delete.)

## Additional Context

- **Breaking:** none — `removeAuth` signature unchanged; behavior is more tolerant on expected paths
- **Risk:** Users who relied on ambiguous error text for scripting are unaffected; legitimate permission/I/O failures still warn and report
- **Follow-up:** none required for merge; acceptance suite still gated by env (same as today)

## Related Issue
GUS work item: [W-22068168](https://gus.lightning.force.com/a07EE00002YJCIxYAP)