### PR TITLE
fix: dedupe API warning headers within one client invocation

### DIFF
--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -100,6 +100,7 @@ export class APIClient {
       protocol: apiUrl.protocol,
     }
     const delinquencyConfig: IDelinquencyConfig = {fetch_delinquency: false, warning_shown: false}
+    const shownHeaderWarnings = new Set<string>()
     this.http = class APIHTTPClient<T> extends HTTP.create(opts)<T> {
       static configDelinquency(url: string, opts: APIClient.Options): void {
         if (opts.method?.toUpperCase() !== 'GET' || (opts.hostname && opts.hostname !== apiUrl.hostname)) {
@@ -247,10 +248,17 @@ export class APIClient {
 
       static showWarnings<T>(response: HTTP<T>) {
         const warnings = response.headers['x-heroku-warning'] || response.headers['warning-message']
+        const emitIfNew = (raw: string) => {
+          const normalized = raw.replace(/^\s*warning:?\s*/i, '').trim()
+          if (!normalized || shownHeaderWarnings.has(normalized)) return
+          shownHeaderWarnings.add(normalized)
+          warn(normalized)
+        }
+
         if (Array.isArray(warnings))
-          for (const warning of warnings) warn(warning.replace(/^\s*warning:?\s*/i, ''))
+          for (const warning of warnings) emitIfNew(warning)
         else if (typeof warnings === 'string')
-          warn(warnings.replace(/^\s*warning:?\s*/i, ''))
+          emitIfNew(warnings)
       }
 
       static trackRequestIds<T>(response: HTTP<T>) {

--- a/test/api-client.test.ts
+++ b/test/api-client.test.ts
@@ -603,6 +603,60 @@ describe('api_client', () => {
         expect(stderr.output).to.contain('Warning: some other warning')
         expect(stderr.output).not.to.contain('Warning: Warning: some other warning')
       })
+
+    test
+      .it('does not repeat the same warning on subsequent identical responses', async ctx => {
+        api = nock('https://api.heroku.com', {
+          reqheaders: {authorization: 'Bearer mypass'},
+        })
+        api.get('/apps').twice().reply(200, [], {'X-Heroku-Warning': 'Your account password will expire soon.'})
+
+        const cmd = new Command([], ctx.config)
+        stderr.start()
+        await cmd.heroku.get('/apps')
+        await cmd.heroku.get('/apps')
+        stderr.stop()
+
+        expect(stderr.output.match(/Warning: Your account password will expire soon\./g)?.length).to.equal(1)
+      })
+
+    test
+      .it('shows distinct warnings from successive responses', async ctx => {
+        api = nock('https://api.heroku.com', {
+          reqheaders: {authorization: 'Bearer mypass'},
+        })
+        api.get('/apps').twice().reply(200, [], {'X-Heroku-Warning': 'First warning'})
+        api.get('/apps/foo').reply(200, [], {'X-Heroku-Warning': 'Second warning'})
+
+        const cmd = new Command([], ctx.config)
+        stderr.start()
+        await cmd.heroku.get('/apps')
+        await cmd.heroku.get('/apps')
+        await cmd.heroku.get('/apps/foo')
+        stderr.stop()
+
+        expect(stderr.output).to.contain('Warning: First warning')
+        expect(stderr.output.match(/Warning: First warning/g)?.length).to.equal(1)
+        expect(stderr.output).to.contain('Warning: Second warning')
+        expect(stderr.output.match(/Warning: Second warning/g)?.length).to.equal(1)
+      })
+
+    test
+      .it('shows the same header warning again for a new command instance', async ctx => {
+        api = nock('https://api.heroku.com', {
+          reqheaders: {authorization: 'Bearer mypass'},
+        })
+        api.get('/apps').twice().reply(200, [], {'X-Heroku-Warning': 'Password expiry reminder'})
+
+        const cmd1 = new Command([], ctx.config)
+        const cmd2 = new Command([], ctx.config)
+        stderr.start()
+        await cmd1.heroku.get('/apps')
+        await cmd2.heroku.get('/apps')
+        stderr.stop()
+
+        expect(stderr.output.match(/Warning: Password expiry reminder/g)?.length).to.equal(2)
+      })
   })
 
   context('with Warning-Message header set on response', function () {


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary

Deduplicate `X-Heroku-Warning` / `Warning-Message` header output by normalized text within a single `APIClient` instance so repeated API calls (e.g. polling) do not print the same warning multiple times or disrupt progress UI.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [x] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [x] **test**: Add/update/remove tests

## Testing
**Notes**:

**Steps**:
1. Passing CI suffices

## Screenshots (if applicable)
N/A

## Related Issues
GitHub issue: N/A
GUS work item: [W-17300765](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000025tkGbYAI/view)