### PR TITLE
feat: revoke OAuth tokens on logout with optional flag

### DIFF
--- a/src/login.ts
+++ b/src/login.ts
@@ -153,10 +153,10 @@ export class Login {
       // grab the default authorization because that is the token shown in the
       // dashboard as API Key and they may be using it for something else and we
       // would unwittingly break an integration that they are depending on
-        const d = await this.defaultToken()
-        if (d === resolvedToken) return
+        const defaultApiToken = await this.defaultToken()
+        if (defaultApiToken && this.isSameToken(resolvedToken, defaultApiToken)) return
         return Promise.all(authorizations
-          .filter(a => a.access_token && a.access_token.token === resolvedToken)
+          .filter(a => a.access_token?.token && this.isSameToken(resolvedToken, a.access_token.token))
           .map(a => HTTP.delete(`${vars.apiUrl}/oauth/authorizations/${a.id}`, headers(resolvedToken))))
       })
       .catch(error => {
@@ -309,6 +309,13 @@ export class Login {
 
     this.heroku.setAuthEntry({account: auth.login, token: auth.password})
     return auth
+  }
+
+  private isSameToken(localToken: string, apiToken: string): boolean {
+    const pattern = apiToken
+      .replace(/[.+?^${}()|[\]\\]/g, String.raw`\$&`)
+      .replace(/\*/g, '[^*]')
+    return new RegExp(`^${pattern}$`).test(localToken)
   }
 
   private async saveToken(entry: NetrcEntry) {

--- a/src/login.ts
+++ b/src/login.ts
@@ -18,6 +18,7 @@ import {vars} from './vars.js'
 const cliDebug = debug('heroku-cli-command')
 const hostname = os.hostname()
 const thirtyDays = 60 * 60 * 24 * 30
+const REDACTED_TOKEN_ASTERISKS = '*'.repeat(10)
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace Login {
@@ -154,9 +155,9 @@ export class Login {
       // dashboard as API Key and they may be using it for something else and we
       // would unwittingly break an integration that they are depending on
         const defaultApiToken = await this.defaultToken()
-        if (defaultApiToken && this.isSameToken(resolvedToken, defaultApiToken)) return
+        if (defaultApiToken && this.isCurrentOAuthToken(resolvedToken, defaultApiToken)) return
         return Promise.all(authorizations
-          .filter(a => a.access_token?.token && this.isSameToken(resolvedToken, a.access_token.token))
+          .filter(a => a.access_token?.token && this.isCurrentOAuthToken(resolvedToken, a.access_token.token))
           .map(a => HTTP.delete(`${vars.apiUrl}/oauth/authorizations/${a.id}`, headers(resolvedToken))))
       })
       .catch(error => {
@@ -311,11 +312,17 @@ export class Login {
     return auth
   }
 
-  private isSameToken(localToken: string, apiToken: string): boolean {
-    const pattern = apiToken
-      .replace(/[.+?^${}()|[\]\\]/g, String.raw`\$&`)
-      .replace(/\*/g, '[^*]')
-    return new RegExp(`^${pattern}$`).test(localToken)
+  private isCurrentOAuthToken(localToken: string, apiToken: string): boolean {
+    const asteriskIndex = apiToken.indexOf(REDACTED_TOKEN_ASTERISKS)
+
+    if (asteriskIndex === -1) {
+      // raw value stored, direct match works
+      return localToken === apiToken
+    }
+
+    const prefix = apiToken.slice(0, asteriskIndex)
+    const suffix = apiToken.slice(asteriskIndex + REDACTED_TOKEN_ASTERISKS.length)
+    return localToken.startsWith(prefix) && (suffix === '' || localToken.endsWith(suffix))
   }
 
   private async saveToken(entry: NetrcEntry) {

--- a/src/login.ts
+++ b/src/login.ts
@@ -25,6 +25,7 @@ export namespace Login {
   export interface Options {
     browser?: string
     expiresIn?: number
+    keepExistingSession?: boolean
     method?: 'browser' | 'interactive' | 'sso'
   }
 }
@@ -87,7 +88,7 @@ export class Login {
       }
 
       try {
-        if (previousToken && !getStorageConfig().credentialStore) await this.logout(previousToken)
+        if (previousToken && !opts.keepExistingSession) await this.logout(previousToken)
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error)
         ux.warn(message)

--- a/test/login.test.ts
+++ b/test/login.test.ts
@@ -55,6 +55,7 @@ describe('login with interactive', () => {
   afterEach(() => {
     sinon.restore()
     restoreCredentialManagerStub()
+    nock.cleanAll()
   })
 
   test
@@ -194,4 +195,132 @@ describe('login with browser', () => {
       expect(() => (login as any).getLoginMethodFromPromptKey('\u0003')).to.throw('cancelled')
       expect(errorStub.calledWithExactly('Login cancelled by user', {exit: 130})).to.equal(true)
     })
+})
+
+describe('logout', () => {
+  let api: nock.Scope
+
+  beforeEach(() => {
+    api = nock('https://api.heroku.com')
+    api.delete('/oauth/sessions/~').reply(200, {})
+  })
+
+  afterEach(() => {
+    sinon.restore()
+    restoreCredentialManagerStub()
+    nock.cleanAll()
+  })
+
+  test
+    .it('deletes the matching authorization', async ctx => {
+      const token = 'fake-token-abc'
+      api.get('/oauth/authorizations').reply(200, [
+        {access_token: {token}, id: 'auth-id-1'},
+        {access_token: {token: 'fake-token-other'}, id: 'auth-id-2'},
+      ])
+      api.get('/oauth/authorizations/~').reply(200, {access_token: {token: 'fake-token-default'}})
+      const deleteStub = api.delete('/oauth/authorizations/auth-id-1').reply(200, {})
+
+      setCredentialManagerProvider({
+        async getAuth() {
+          return {account: 'test@example.com', token}
+        },
+        async removeAuth() {},
+        async saveAuth() {},
+      })
+      const cmd = new Command([], ctx.config)
+      await cmd.heroku.logout()
+
+      expect(deleteStub.isDone()).to.equal(true)
+    })
+
+  test
+    .it('does not delete the default API key authorization', async ctx => {
+      const token = 'fake-token-abc'
+      api.get('/oauth/authorizations').reply(200, [
+        {access_token: {token}, id: 'auth-id-1'},
+      ])
+      api.get('/oauth/authorizations/~').reply(200, {access_token: {token}})
+      const deleteStub = api.delete('/oauth/authorizations/auth-id-1').reply(200, {})
+
+      setCredentialManagerProvider({
+        async getAuth() {
+          return {account: 'test@example.com', token}
+        },
+        async removeAuth() {},
+        async saveAuth() {},
+      })
+      const cmd = new Command([], ctx.config)
+      await cmd.heroku.logout()
+
+      expect(deleteStub.isDone()).to.equal(false)
+    })
+
+  test
+    .it('does not delete any authorization when no token matches', async ctx => {
+      const token = 'fake-token-abc'
+      api.get('/oauth/authorizations').reply(200, [
+        {access_token: {token: 'fake-token-other'}, id: 'auth-id-1'},
+      ])
+      api.get('/oauth/authorizations/~').reply(200, {access_token: {token: 'fake-token-default'}})
+      const deleteStub = api.delete('/oauth/authorizations/auth-id-1').reply(200, {})
+
+      setCredentialManagerProvider({
+        async getAuth() {
+          return {account: 'test@example.com', token}
+        },
+        async removeAuth() {},
+        async saveAuth() {},
+      })
+      const cmd = new Command([], ctx.config)
+      await cmd.heroku.logout()
+
+      expect(deleteStub.isDone()).to.equal(false)
+    })
+
+  test
+    .it('does not error when authorizations list is empty', async ctx => {
+      const token = 'fake-token-abc'
+      api.get('/oauth/authorizations').reply(200, [])
+      api.get('/oauth/authorizations/~').reply(200, {})
+
+      setCredentialManagerProvider({
+        async getAuth() {
+          return {account: 'test@example.com', token}
+        },
+        async removeAuth() {},
+        async saveAuth() {},
+      })
+      const cmd = new Command([], ctx.config)
+      await cmd.heroku.logout()
+    })
+})
+
+describe('isCurrentOAuthToken', () => {
+  const login = new Login(null as any, null as any)
+  const match = (localToken: string, apiToken: string) =>
+    (login as any).isCurrentOAuthToken(localToken, apiToken)
+
+  it('matches identical unredacted tokens', () => {
+    expect(match('fake-token-abc', 'fake-token-abc')).to.equal(true)
+  })
+
+  it('does not match different unredacted tokens', () => {
+    expect(match('fake-token-abc', 'fake-token-xyz')).to.equal(false)
+  })
+
+  it('matches redacted tokens with correct prefix and suffix', () => {
+    expect(match('prefixABCDEFGHIJKLMNOPQRSTUVWXYZsuffix', 'prefix**********suffix')).to.equal(true)
+    expect(match('prefixABCDEFGHIJKLMNOPQRSTUVWXYZ', 'prefix**********')).to.equal(true)
+  })
+
+  it('does not match when prefix differs', () => {
+    expect(match('xxxxxABCDEFGHIJKLMNOPQRSTUVWXYZsuffix', 'prefix**********suffix')).to.equal(false)
+    expect(match('xxxxxABCDEFGHIJKLMNOPQRSTUVWXYZ', 'prefix**********')).to.equal(false)
+  })
+
+  it('does not match when suffix differs', () => {
+    expect(match('prefixABCDEFGHIJKLMNOPQRSTUVWXYZxxxxx', 'prefix**********suffix')).to.equal(false)
+    expect(match('prefixABCDEFGHIJKLMNOPQRSTUVWXYZ', 'prefix**********suffix')).to.equal(false)
+  })
 })

--- a/test/login.test.ts
+++ b/test/login.test.ts
@@ -166,6 +166,55 @@ describe('login with interactive', () => {
           expect(error.message).to.contain('Cannot set an expiration longer than thirty days')
         })
     })
+
+  test
+    .it('revokes the existing session by default when already logged in', async ctx => {
+      nock.cleanAll()
+
+      api.delete('/oauth/sessions/~').reply(200, {})
+      api.get('/oauth/authorizations').reply(200, [])
+      api.get('/oauth/authorizations/~').reply(200, {})
+      api.post('/oauth/authorizations').reply(200, {
+        access_token: {token: 'new-token'},
+        user: {email: 'test@example.com'},
+      })
+
+      setCredentialManagerProvider({
+        async getAuth() {
+          return {account: 'test@example.com', token: 'previous-token'}
+        },
+        async removeAuth() {},
+        async saveAuth() {},
+      })
+
+      const cmd = new Command([], ctx.config)
+      await cmd.heroku.login({method: 'interactive'})
+
+      expect(api.isDone()).to.equal(true)
+    })
+
+  test
+    .it('keeps the existing session when keepExistingSession is true', async ctx => {
+      nock.cleanAll()
+      api.delete('/oauth/sessions/~').reply(200, {})
+      api.post('/oauth/authorizations').reply(200, {
+        access_token: {token: 'new-token'},
+        user: {email: 'test@example.com'},
+      })
+
+      setCredentialManagerProvider({
+        async getAuth() {
+          return {account: 'test@example.com', token: 'previous-token'}
+        },
+        async removeAuth() {},
+        async saveAuth() {},
+      })
+
+      const cmd = new Command([], ctx.config)
+      await cmd.heroku.login({keepExistingSession: true, method: 'interactive'})
+
+      expect(api.isDone()).to.equal(false)
+    })
 })
 
 describe('login with browser', () => {


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary
<!-- Brief description of the changes in this PR. -->
The Heroku API returns redacted OAuth tokens from GET /oauth/authorizations, rather than the full token value. This caused the logout flow to silently skip revoking the active authorization, leaving tokens valid after logout.

### Changes:
- Added `isCurrentOAuthToken()` to match the locally stored raw token against the redacted API token by comparing the visible prefix and suffix
- Fixed the `defaultToken()` guard to use the same redacted matching, preventing accidental deletion of the default API key authorization
- Added `keepExistingSession` as an internal `Login.Options` flag for commands that need to switch accounts without revoking the previous session (e.g. the `heroku accounts` commands)
- Added tests for `isCurrentOAuthToken()` and `keepExistingSession`

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [x] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [x] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**: 
<!-- Add any context/setup necessary for testing. -->

**Steps**:
1. Pull down this branch
2. `heroku logout`
3. `npm install && npm run build`
4. `npm run example -- login`
5. `npm run example -- whoami` — should output the account email
6. Open `~/.netrc` and copy the auth token
7. `npm run example -- logout`
8. `HEROKU_API_KEY=<copied_token> npm run example -- whoami` — should error that the token provided to `HEROKU_API_KEY` is invalid

## Screenshots (if applicable)

## Related Issues
GUS work item: [W-22313470](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002ZBLs0YAH/view)
