### PR TITLE
feat: update login to no longer logout as part of the process

### DIFF
--- a/src/login.ts
+++ b/src/login.ts
@@ -25,7 +25,6 @@ export namespace Login {
   export interface Options {
     browser?: string
     expiresIn?: number
-    keepExistingSession?: boolean
     method?: 'browser' | 'interactive' | 'sso'
   }
 }
@@ -85,13 +84,6 @@ export class Login {
           ux.stdout('')
           input = this.getLoginMethodFromPromptKey(key)
         }
-      }
-
-      try {
-        if (previousToken && !opts.keepExistingSession) await this.logout(previousToken)
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error)
-        ux.warn(message)
       }
 
       let auth

--- a/test/login.test.ts
+++ b/test/login.test.ts
@@ -168,16 +168,17 @@ describe('login with interactive', () => {
     })
 
   test
-    .it('revokes the existing session by default when already logged in', async ctx => {
+    .it('does not automatically revoke existing session when logging in', async ctx => {
       nock.cleanAll()
 
-      api.delete('/oauth/sessions/~').reply(200, {})
       api.get('/oauth/authorizations').reply(200, [])
       api.get('/oauth/authorizations/~').reply(200, {})
       api.post('/oauth/authorizations').reply(200, {
         access_token: {token: 'new-token'},
         user: {email: 'test@example.com'},
       })
+
+      const deleteStub = api.delete('/oauth/sessions/~').reply(200, {})
 
       setCredentialManagerProvider({
         async getAuth() {
@@ -190,30 +191,7 @@ describe('login with interactive', () => {
       const cmd = new Command([], ctx.config)
       await cmd.heroku.login({method: 'interactive'})
 
-      expect(api.isDone()).to.equal(true)
-    })
-
-  test
-    .it('keeps the existing session when keepExistingSession is true', async ctx => {
-      nock.cleanAll()
-      api.delete('/oauth/sessions/~').reply(200, {})
-      api.post('/oauth/authorizations').reply(200, {
-        access_token: {token: 'new-token'},
-        user: {email: 'test@example.com'},
-      })
-
-      setCredentialManagerProvider({
-        async getAuth() {
-          return {account: 'test@example.com', token: 'previous-token'}
-        },
-        async removeAuth() {},
-        async saveAuth() {},
-      })
-
-      const cmd = new Command([], ctx.config)
-      await cmd.heroku.login({keepExistingSession: true, method: 'interactive'})
-
-      expect(api.isDone()).to.equal(false)
+      expect(deleteStub.isDone()).to.equal(false)
     })
 })
 


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary
<!-- Brief description of the changes in this PR. -->
Updates the login process so that it no longer includes logging the user out. This enables the user to have multiple Heroku user accounts saved in their local keychain.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [x] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**: 
<!-- Add any context/setup necessary for testing. -->

**Steps**:
1. Check out this branch and run `npm i && npm run build`
2. Login to Heroku using `npm run example login`
3. Open your Keychain Access application and search for `Heroku`. You should find the account you just logged in with.
4. Login to a second Heroku account using `npm run example login`
5. In your Keychain Access application you should now see two entries, one for the first account and one for the second.

## Screenshots (if applicable)

## Related Issues
GUS work item: [W-22421104](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002Zel9rYAB/view)
