### PR TITLE
fix: update login state file for both keychain and .netrc

### DIFF
--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -5,7 +5,6 @@ import {CLIError, warn} from '@oclif/core/errors'
 import debug from 'debug'
 import * as url from 'node:url'
 
-import {getStorageConfig} from './credential-manager-core/lib/credential-storage-selector.js'
 import {deleteLoginState, readLoginState} from './credential-manager-core/lib/login-state.js'
 import {type AuthEntry, getAuth as getStoredAuth, removeAuth} from './credential-manager.js'
 import {Login} from './login.js'
@@ -347,8 +346,7 @@ export class APIClient {
 
     if (!this._storedAuthPromise) {
       this._storedAuthPromise = (async (): Promise<AuthEntry | undefined> => {
-        const {credentialStore} = getStorageConfig()
-        const useLoginState = Boolean(credentialStore && this.config.dataDir)
+        const useLoginState = Boolean(this.config.dataDir)
         try {
           const cachedAccount = useLoginState
             ? (await readLoginState(this.config.dataDir))?.account
@@ -444,8 +442,7 @@ export class APIClient {
   }
 
   private async clearLoginState(): Promise<void> {
-    const config = getStorageConfig()
-    if (config.credentialStore && this.config.dataDir) {
+    if (this.config.dataDir) {
       await deleteLoginState(this.config.dataDir)
     }
   }

--- a/src/login.ts
+++ b/src/login.ts
@@ -9,7 +9,6 @@ import os from 'node:os'
 import * as readline from 'node:readline'
 
 import {APIClient, HerokuAPIError} from './api-client.js'
-import {getStorageConfig} from './credential-manager-core/lib/credential-storage-selector.js'
 import {writeLoginState} from './credential-manager-core/lib/login-state.js'
 import {saveAuth} from './credential-manager.js'
 import {prompter} from './prompter.js'
@@ -320,8 +319,7 @@ export class Login {
 
   private async saveToken(entry: NetrcEntry) {
     await saveAuth(entry.login, entry.password, [vars.apiHost, vars.httpGitHost])
-    const config = getStorageConfig()
-    if (config.credentialStore && this.config.dataDir) {
+    if (this.config.dataDir) {
       await writeLoginState(this.config.dataDir, entry.login)
     }
   }

--- a/test/api-client.test.ts
+++ b/test/api-client.test.ts
@@ -270,6 +270,76 @@ describe('api_client', () => {
       })
   })
 
+  describe('login state file with HEROKU_NETRC_WRITE', () => {
+    let tmpDir: string
+    let platformStub: sinon.SinonStub
+
+    beforeEach(() => {
+      tmpDir = fs.mkdtempSync(join(SYSTEM_TMPDIR, 'heroku-api-client-netrc-'))
+      platformStub = sinon.stub(process, 'platform').value('darwin')
+      process.env.HEROKU_NETRC_WRITE = 'true'
+    })
+
+    afterEach(() => {
+      fs.rmSync(tmpDir, {force: true, recursive: true})
+      delete process.env.HEROKU_NETRC_WRITE
+      platformStub.restore()
+    })
+
+    test
+      .it('deletes login.json on logout even in netrc-only mode', async ctx => {
+        setCredentialManagerProvider({
+          async getAuth() {
+            return {account: 'netrc-logout@example.com', token: 'netrc-logout-token'}
+          },
+          async removeAuth() {},
+          async saveAuth() {},
+        })
+        await writeLoginState(tmpDir, 'netrc-logout@example.com')
+        api.delete('/oauth/sessions/~').reply(200, {})
+        api.get('/oauth/authorizations').reply(200, [])
+        api.get('/oauth/authorizations/~').reply(200, {})
+        const cmd = new Command([], ctx.config)
+        cmd.config = {...ctx.config, dataDir: tmpDir} as Config
+        await cmd.heroku.logout()
+        expect(fs.existsSync(join(tmpDir, 'login.json'))).to.be.false
+      })
+
+    test
+      .it('reads login.json and passes account to getAuth even in netrc-only mode', async ctx => {
+        let receivedAccount: string | undefined
+        setCredentialManagerProvider({
+          async getAuth(account) {
+            receivedAccount = account
+            return {account: account ?? 'fallback@example.com', token: 'netrc-token'}
+          },
+          async removeAuth() {},
+          async saveAuth() {},
+        })
+        await writeLoginState(tmpDir, 'netrc-cached@example.com')
+        const cmd = new Command([], ctx.config)
+        cmd.config = {...ctx.config, dataDir: tmpDir} as Config
+        await cmd.heroku.getAuthEntry()
+        expect(receivedAccount).to.equal('netrc-cached@example.com')
+      })
+
+    test
+      .it('clears stale login.json when credential store has no matching account in netrc-only mode', async ctx => {
+        setCredentialManagerProvider({
+          async getAuth() {
+            throw new Error('No auth found')
+          },
+          async removeAuth() {},
+          async saveAuth() {},
+        })
+        await writeLoginState(tmpDir, 'stale-netrc@example.com')
+        const cmd = new Command([], ctx.config)
+        cmd.config = {...ctx.config, dataDir: tmpDir} as Config
+        await cmd.heroku.getAuthEntry()
+        expect(fs.existsSync(join(tmpDir, 'login.json'))).to.be.false
+      })
+  })
+
   describe('setAuthEntry', () => {
     test
       .it('updates auth getter and subsequent getAuthEntry without calling credential store', async ctx => {


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary
<!-- Brief description of the changes in this PR. -->
Adds support for managing/using the login state file in .netrc mode. Previously this was only supported for keychain mode. This update should resolve an issue where users were not seeing a warning message running a command in keychain mode (without `HEROKU_NETRC_WRITE=true`) after logging in in .netrc mode (with `HEROKU_NETRC_WRITE=true`).

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [x] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**: 
<!-- Add any context/setup necessary for testing. -->
We can't test this with the CLI using `npm link`, it causes all sorts of TypeScript errors. Once this PR is merged I will release a beta that we can test.

**Steps**:
1. Passing CI suffices

## Screenshots (if applicable)

## Related Issues
GUS work item: [W-20867320](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002Ske9RYAR/view)
