### PR TITLE
fix: remove .netrc warnings from the credential manager

### DIFF
--- a/src/credential-manager-core/index.ts
+++ b/src/credential-manager-core/index.ts
@@ -1,6 +1,4 @@
-import {ux} from '@oclif/core'
 import debug from 'debug'
-import tsheredoc from 'tsheredoc'
 
 import {LinuxHandler} from './credential-handlers/linux-handler.js'
 import {MacOSHandler} from './credential-handlers/macos-handler.js'
@@ -11,7 +9,6 @@ import {CredentialStore, getNativeCredentialStore, getStorageConfig} from './lib
 import {AuthEntry, NetrcAuthEntry} from './lib/types.js'
 
 const credDebug = debug('heroku-credential-manager')
-const heredoc = tsheredoc.default
 
 const SERVICE_NAME = 'heroku-cli'
 
@@ -35,12 +32,6 @@ export async function saveAuth(account: string, token: string, hosts: string[], 
     } catch (error) {
       const {message} = error as Error
       credDebug(message)
-      if (process.env.HEROKU_KEYCHAIN_WARNINGS !== 'off') {
-        ux.warn(heredoc(`
-          We can't save the Heroku token to your computer's keychain.
-          We'll save the token to the .netrc file instead.
-          To turn off this warning, set HEROKU_KEYCHAIN_WARNINGS to "off".`))
-      }
 
       await reportCredentialStoreError(error, {
         credentialStore: config.credentialStore,
@@ -70,7 +61,6 @@ export async function saveAuth(account: string, token: string, hosts: string[], 
 export async function getAuth(account: string | undefined, host: string, service = SERVICE_NAME): Promise<AuthEntry> {
   const config = getStorageConfig()
   const netrcHandler = new NetrcHandler()
-  let warningShown = false
 
   if (config.credentialStore && account) {
     try {
@@ -80,15 +70,6 @@ export async function getAuth(account: string | undefined, host: string, service
     } catch (error) {
       const {message} = error as Error
       credDebug(message)
-      if (process.env.HEROKU_KEYCHAIN_WARNINGS !== 'off') {
-        ux.warn(heredoc(`
-          We can't retrieve the Heroku token from your computer's keychain.
-          We'll try to retrieve the token from the .netrc file instead.
-          To turn off this warning, set HEROKU_KEYCHAIN_WARNINGS to "off".`))
-
-        // avoid showing the warning multiple times
-        warningShown = true
-      }
 
       await reportCredentialStoreError(error, {
         credentialStore: config.credentialStore,
@@ -98,13 +79,6 @@ export async function getAuth(account: string | undefined, host: string, service
   }
 
   if (config.useNetrc) {
-    if (process.env.HEROKU_KEYCHAIN_WARNINGS !== 'off' && config.credentialStore && !warningShown) {
-      ux.warn(heredoc(`
-          We can't retrieve the Heroku token from your computer's keychain.
-          We'll try to retrieve the token from the .netrc file instead.
-          To turn off this warning, set HEROKU_KEYCHAIN_WARNINGS to "off".`))
-    }
-
     const auth = await netrcHandler.getAuth(host)
 
     if (!auth.password) {
@@ -167,12 +141,6 @@ export async function removeAuth(account: string | undefined, hosts: string[], s
     } catch (error) {
       const {message} = error as Error
       credDebug(message)
-      if (process.env.HEROKU_KEYCHAIN_WARNINGS !== 'off') {
-        ux.warn(heredoc(`
-          We can't remove the Heroku token from your computer's keychain.
-          We'll remove the token from the .netrc file instead.
-          To turn off this warning, set HEROKU_KEYCHAIN_WARNINGS to "off".`))
-      }
 
       await reportCredentialStoreError(error, {
         credentialStore: nativeStore,

--- a/test/credential-manager/acceptance/index.acceptance.test.ts
+++ b/test/credential-manager/acceptance/index.acceptance.test.ts
@@ -1,9 +1,7 @@
 import {expect, use} from 'chai'
 import chaiAsPromised from 'chai-as-promised'
-import {stderr} from 'stdout-stderr'
 
 import {getAuth, removeAuth, saveAuth} from '../../../src/credential-manager-core/index.js'
-import {unwrap} from '../../helpers/unwrap.js'
 import {
   cleanupCredentialStore,
   cleanupDefaultNetrc,

--- a/test/credential-manager/acceptance/index.acceptance.test.ts
+++ b/test/credential-manager/acceptance/index.acceptance.test.ts
@@ -213,13 +213,7 @@ describe('credential-manager acceptance', function () {
       }
 
       try {
-        stderr.start()
         await saveAuth(CREDENTIAL.account, CREDENTIAL.token, CREDENTIAL.hosts, CREDENTIAL.service)
-        stderr.stop()
-
-        expect(unwrap(stderr.output)).to.contain('We can\'t save the Heroku token to your computer\'s keychain.')
-        expect(unwrap(stderr.output)).to.contain('We\'ll save the token to the .netrc file instead.')
-        expect(unwrap(stderr.output)).to.contain('To turn off this warning, set HEROKU_KEYCHAIN_WARNINGS to "off".')
 
         const netrcAuth = await getAuth('missing-account@example.com', CREDENTIAL.hosts[0], CREDENTIAL.service)
         expect(netrcAuth).to.deep.equal({account: CREDENTIAL.account, token: CREDENTIAL.token})

--- a/test/credential-manager/index.test.ts
+++ b/test/credential-manager/index.test.ts
@@ -88,16 +88,10 @@ describe('credential-manager', function () {
       const macosStub = sinon.stub(MacOSHandler.prototype, 'saveAuth').throws(new Error('Keychain error'))
       const netrcStub = sinon.stub(NetrcHandler.prototype, 'saveAuthForHosts').resolves()
 
-      stderr.start()
       await credentialManager.saveAuth('user@example.com', 'test-token', ['api.heroku.com'])
 
       expect(macosStub.calledOnce).to.be.true
       expect(netrcStub.calledOnce).to.be.true
-      expect(unwrap(stderr.output)).to.contain('Warning: We can\'t save the Heroku token to your computer\'s keychain.')
-      expect(unwrap(stderr.output)).to.contain('We\'ll save the token to the .netrc file instead.')
-      expect(unwrap(stderr.output)).to.contain('To turn off this warning, set HEROKU_KEYCHAIN_WARNINGS to "off".')
-
-      stderr.stop()
     })
 
     it('should save to credential store once and netrc once for multiple hosts', async function () {
@@ -192,56 +186,24 @@ describe('credential-manager', function () {
       const netrcStub = sinon.stub(NetrcHandler.prototype, 'getAuth')
       netrcStub.resolves({login: 'user@example.com', password: 'netrc-token'})
 
-      stderr.start()
-
       const auth = await credentialManager.getAuth('user@example.com', 'api.heroku.com')
 
       expect(macosStub.calledOnce).to.be.true
       expect(netrcStub.calledOnce).to.be.true
       expect(netrcStub.firstCall.args[0]).to.equal('api.heroku.com')
       expect(auth).to.deep.equal({account: 'user@example.com', token: 'netrc-token'})
-      expect(unwrap(stderr.output)).to.contain('Warning: We can\'t retrieve the Heroku token from your computer\'s keychain.')
-      expect(unwrap(stderr.output)).to.contain('We\'ll try to retrieve the token from the .netrc file instead.')
-      expect(unwrap(stderr.output)).to.contain('To turn off this warning, set HEROKU_KEYCHAIN_WARNINGS to "off".')
-
-      stderr.stop()
     })
 
-    it('should show netrc fallback warning when credentialStore is set but no account is provided', async function () {
-      const macosStub = sinon.stub(MacOSHandler.prototype, 'getAuth')
-      const netrcStub = sinon.stub(NetrcHandler.prototype, 'getAuth')
-      netrcStub.resolves({login: 'user@example.com', password: 'netrc-token'})
-
-      stderr.start()
-
-      const auth = await credentialManager.getAuth(undefined, 'api.heroku.com')
-
-      expect(macosStub.notCalled).to.be.true
-      expect(netrcStub.calledOnce).to.be.true
-      expect(auth).to.deep.equal({account: 'user@example.com', token: 'netrc-token'})
-      expect(unwrap(stderr.output)).to.contain('We can\'t retrieve the Heroku token from your computer\'s keychain.')
-      expect(unwrap(stderr.output)).to.contain('We\'ll try to retrieve the token from the .netrc file instead.')
-      expect(unwrap(stderr.output)).to.contain('To turn off this warning, set HEROKU_KEYCHAIN_WARNINGS to "off".')
-
-      stderr.stop()
-    })
 
     it('should throw error when credentials are not found in either location', async function () {
       const macosStub = sinon.stub(MacOSHandler.prototype, 'getAuth').throws(new Error('Not found'))
       const netrcStub = sinon.stub(NetrcHandler.prototype, 'getAuth')
       netrcStub.rejects(new Error('No auth found for api.heroku.com'))
 
-      stderr.start()
-
       await expect(credentialManager.getAuth('user@example.com', 'api.heroku.com'))
         .to.be.rejectedWith(Error, 'No auth found for api.heroku.com')
       expect(macosStub.calledOnce).to.be.true
       expect(netrcStub.calledOnce).to.be.true
-      expect(unwrap(stderr.output)).to.contain('Warning: We can\'t retrieve the Heroku token from your computer\'s keychain.')
-      expect(unwrap(stderr.output)).to.contain('We\'ll try to retrieve the token from the .netrc file instead.')
-      expect(unwrap(stderr.output)).to.contain('To turn off this warning, set HEROKU_KEYCHAIN_WARNINGS to "off".')
-
-      stderr.stop()
     })
 
     it('should throw error when netrc password is empty', async function () {
@@ -249,17 +211,10 @@ describe('credential-manager', function () {
       const netrcStub = sinon.stub(NetrcHandler.prototype, 'getAuth')
       netrcStub.resolves({login: 'user@example.com', password: undefined})
 
-      stderr.start()
-
       await expect(credentialManager.getAuth('user@example.com', 'api.heroku.com'))
         .to.be.rejectedWith(Error, 'No auth found')
       expect(macosStub.calledOnce).to.be.true
       expect(netrcStub.calledOnce).to.be.true
-      expect(unwrap(stderr.output)).to.contain('Warning: We can\'t retrieve the Heroku token from your computer\'s keychain.')
-      expect(unwrap(stderr.output)).to.contain('We\'ll try to retrieve the token from the .netrc file instead.')
-      expect(unwrap(stderr.output)).to.contain('To turn off this warning, set HEROKU_KEYCHAIN_WARNINGS to "off".')
-
-      stderr.stop()
     })
 
     it('should fall back to netrc when an account is not provided', async function () {
@@ -342,16 +297,10 @@ describe('credential-manager', function () {
       const macosStub = sinon.stub(MacOSHandler.prototype, 'removeAuth').throws(new Error('Keychain error'))
       const netrcStub = sinon.stub(NetrcHandler.prototype, 'removeAuthForHosts').resolves()
 
-      stderr.start()
       await credentialManager.removeAuth('user@example.com', ['api.heroku.com'])
 
       expect(macosStub.calledOnce).to.be.true
       expect(netrcStub.calledOnce).to.be.true
-      expect(unwrap(stderr.output)).to.contain('Warning: We can\'t remove the Heroku token from your computer\'s keychain.')
-      expect(unwrap(stderr.output)).to.contain('We\'ll remove the token from the .netrc file instead.')
-      expect(unwrap(stderr.output)).to.contain('To turn off this warning, set HEROKU_KEYCHAIN_WARNINGS to "off".')
-
-      stderr.stop()
     })
 
     it('should remove from credential store once and netrc once for multiple hosts', async function () {

--- a/test/credential-manager/index.test.ts
+++ b/test/credential-manager/index.test.ts
@@ -194,7 +194,6 @@ describe('credential-manager', function () {
       expect(auth).to.deep.equal({account: 'user@example.com', token: 'netrc-token'})
     })
 
-
     it('should throw error when credentials are not found in either location', async function () {
       const macosStub = sinon.stub(MacOSHandler.prototype, 'getAuth').throws(new Error('Not found'))
       const netrcStub = sinon.stub(NetrcHandler.prototype, 'getAuth')


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary
  
Removes user-facing warnings when the credential manager falls back from keychain to .netrc file. The fallback behavior remains unchanged; only the warning messages are removed from saveAuth, getAuth, and removeAuth functions.

## Type of Change

### Breaking Changes (major semver update)

- [ ] Add a ! after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)

- [ ] feat: Introduces a new feature to the codebase

### Patch Updates (patch semver update)

- [x] fix: Bug fix
- [ ] deps: Dependency upgrade
- [ ] revert: Revert a previous commit
- [ ] chore: Change that does not affect production code
- [ ] refactor: Refactoring existing code without changing behavior
- [ ] test: Add/update/remove tests

## Testing

Steps:
1. Check out this branch and run npm i && npm run build
2. Test netrc-only mode: HEROKU_NETRC_WRITE=true npm run example login
3. Test keychain mode with .netrc credentials: run npm run example whoami
4. Verify that no warning appears when falling back to netrc

## Screenshots (if applicable)

N/A

## Related Issues
GUS work item: [W-22917303](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002bqrF8YAI/view)
