### PR TITLE
feat!: remove dual write for credential storage

### DIFF
--- a/src/credential-manager-core/index.ts
+++ b/src/credential-manager-core/index.ts
@@ -13,7 +13,7 @@ const credDebug = debug('heroku-credential-manager')
 const SERVICE_NAME = 'heroku-cli'
 
 /**
- * Saves authentication credentials to the native credential store (if available) and .netrc file.
+ * Saves authentication credentials to the native credential store (if available) or .netrc file.
  *
  * @param account - User's account (email)
  * @param token - Authentication token
@@ -24,11 +24,13 @@ const SERVICE_NAME = 'heroku-cli'
 export async function saveAuth(account: string, token: string, hosts: string[], service = SERVICE_NAME): Promise<void> {
   const config = getStorageConfig()
   const netrcHandler = new NetrcHandler()
+  let keychainSuccess = false
 
   if (config.credentialStore) {
     try {
       const handler = getCredentialHandler(config.credentialStore)
       handler.saveAuth({account, service, token})
+      keychainSuccess = true
     } catch (error) {
       const {message} = error as Error
       credDebug(message)
@@ -40,7 +42,8 @@ export async function saveAuth(account: string, token: string, hosts: string[], 
     }
   }
 
-  if (config.useNetrc && hosts.length > 0) {
+  const shouldUseNetrc = config.useNetrc || !keychainSuccess
+  if (shouldUseNetrc && hosts.length > 0) {
     const netrcAuth: NetrcAuthEntry = {
       login: account,
       password: token,
@@ -61,11 +64,13 @@ export async function saveAuth(account: string, token: string, hosts: string[], 
 export async function getAuth(account: string | undefined, host: string, service = SERVICE_NAME): Promise<AuthEntry> {
   const config = getStorageConfig()
   const netrcHandler = new NetrcHandler()
+  let keychainSuccess = false
 
   if (config.credentialStore && account) {
     try {
       const handler = getCredentialHandler(config.credentialStore)
       const token = handler.getAuth(account, service)
+      keychainSuccess = true
       return {account, token}
     } catch (error) {
       const {message} = error as Error
@@ -78,14 +83,13 @@ export async function getAuth(account: string | undefined, host: string, service
     }
   }
 
-  if (config.useNetrc) {
+  const shouldUseNetrc = config.useNetrc || !keychainSuccess
+  if (shouldUseNetrc) {
     const auth = await netrcHandler.getAuth(host)
 
-    if (!auth.password) {
-      throw new Error('No auth found')
+    if (auth.password) {
+      return {account: auth.login, token: auth.password}
     }
-
-    return {account: auth.login, token: auth.password}
   }
 
   throw new Error('No auth found')
@@ -122,7 +126,7 @@ export async function listKeychainAccounts(service = SERVICE_NAME): Promise<stri
 
 /**
  * Removes authentication credentials from the platform native store (when present) and .netrc.
- * Uses {@link getNativeCredentialStore} so legacy HEROKU_NETRC_WRITE-only mode does not skip Keychain/vault cleanup after a mixed login.
+ * Always attempts to remove from both stores to prevent stale tokens when users switch between modes.
  *
  * @param account - User's account (email), or undefined when using HEROKU_API_KEY only (native removal is skipped)
  * @param hosts - Hostname(s) for netrc storage (e.g., ['api.heroku.com'])
@@ -130,7 +134,6 @@ export async function listKeychainAccounts(service = SERVICE_NAME): Promise<stri
  * @returns Promise that resolves when credentials are removed
  */
 export async function removeAuth(account: string | undefined, hosts: string[], service = SERVICE_NAME): Promise<void> {
-  const config = getStorageConfig()
   const netrcHandler = new NetrcHandler()
   const nativeStore = getNativeCredentialStore()
 
@@ -149,7 +152,7 @@ export async function removeAuth(account: string | undefined, hosts: string[], s
     }
   }
 
-  if (config.useNetrc && hosts.length > 0) {
+  if (hosts.length > 0) {
     await netrcHandler.removeAuthForHosts(hosts)
   }
 }

--- a/src/credential-manager-core/index.ts
+++ b/src/credential-manager-core/index.ts
@@ -126,7 +126,7 @@ export async function listKeychainAccounts(service = SERVICE_NAME): Promise<stri
 
 /**
  * Removes authentication credentials from the platform native store (when present) and .netrc.
- * Always attempts to remove from both stores to prevent stale tokens when users switch between modes.
+ * Always attempts to remove from both stores to remove stale tokens when users switch between modes.
  *
  * @param account - User's account (email), or undefined when using HEROKU_API_KEY only (native removal is skipped)
  * @param hosts - Hostname(s) for netrc storage (e.g., ['api.heroku.com'])

--- a/src/credential-manager-core/lib/credential-storage-selector.ts
+++ b/src/credential-manager-core/lib/credential-storage-selector.ts
@@ -56,11 +56,10 @@ export function getNativeCredentialStore(): CredentialStore | null {
 }
 
 /**
- * Determines whether to use OS-native credential storage, .netrc file, or both.
+ * Determines whether to use OS-native credential storage or .netrc file.
  *
- * `HEROKU_NETRC_WRITE=true` alone selects legacy netrc-only reads/writes (no native store on the primary path).
- * `HEROKU_NATIVE_STORE_WRITE=true` skips .netrc on the primary path so the OS native store (Keychain, Secret Service, Windows Credential Manager) can be tested in isolation.
- * When both are `true`, credentials use the native store and .netrc (dual path).
+ * By default, uses keychain exclusively (when available).
+ * `HEROKU_NETRC_WRITE=true` selects netrc-only mode, skipping keychain entirely.
  *
  * @returns Object containing storage configuration
  *
@@ -71,23 +70,24 @@ export function getNativeCredentialStore(): CredentialStore | null {
  *   // Use macOS handler
  * }
  * if (config.useNetrc) {
- *   // Also use netrc handler
+ *   // Use netrc handler (explicit override mode)
  * }
  * ```
  */
 export function getStorageConfig(): StorageConfig {
   const netrcWriteLegacy = process.env.HEROKU_NETRC_WRITE?.toLowerCase() === 'true'
-  const nativeStoreWriteEnabled = process.env.HEROKU_NATIVE_STORE_WRITE?.toLowerCase() === 'true'
 
-  if (netrcWriteLegacy && !nativeStoreWriteEnabled) {
+  if (netrcWriteLegacy) {
     return {
       credentialStore: null,
       useNetrc: true,
     }
   }
 
+  const nativeCredentialStore = getNativeCredentialStore()
+
   return {
-    credentialStore: getNativeCredentialStore(),
-    useNetrc: !nativeStoreWriteEnabled || netrcWriteLegacy,
+    credentialStore: nativeCredentialStore,
+    useNetrc: !nativeCredentialStore,
   }
 }

--- a/test/api-client.test.ts
+++ b/test/api-client.test.ts
@@ -207,12 +207,10 @@ describe('api_client', () => {
     beforeEach(() => {
       tmpDir = fs.mkdtempSync(join(SYSTEM_TMPDIR, 'heroku-api-client-'))
       platformStub = sinon.stub(process, 'platform').value('darwin')
-      process.env.HEROKU_NATIVE_STORE_WRITE = 'true'
     })
 
     afterEach(() => {
       fs.rmSync(tmpDir, {force: true, recursive: true})
-      delete process.env.HEROKU_NATIVE_STORE_WRITE
       platformStub.restore()
     })
 

--- a/test/credential-manager/acceptance/index.acceptance.test.ts
+++ b/test/credential-manager/acceptance/index.acceptance.test.ts
@@ -1,12 +1,13 @@
 import {expect, use} from 'chai'
 import chaiAsPromised from 'chai-as-promised'
 
-import {getAuth, removeAuth, saveAuth} from '../../../src/credential-manager-core/index.js'
+import {
+  getAuth, listKeychainAccounts, Netrc, removeAuth, saveAuth,
+} from '../../../src/credential-manager-core/index.js'
 import {
   cleanupCredentialStore,
   cleanupDefaultNetrc,
   CREDENTIAL_FIXTURES,
-  listCredentialStoreAccounts,
   setupFakeCredentialStore,
   skipUnlessAcceptance,
   snapshotDefaultNetrc,
@@ -103,8 +104,15 @@ describe('credential-manager acceptance', function () {
     it('skips credential store', async function () {
       await saveAuth(CREDENTIAL.account, CREDENTIAL.token, CREDENTIAL.hosts, CREDENTIAL.service)
 
-      const {accounts} = listCredentialStoreAccounts(CREDENTIAL.service)
+      const accounts = await listKeychainAccounts(CREDENTIAL.service)
       expect(accounts).to.deep.equal([])
+    })
+
+    it('errors when password is empty', async function () {
+      await saveAuth(CREDENTIAL.account, '', CREDENTIAL.hosts, CREDENTIAL.service)
+
+      await expect(getAuth(CREDENTIAL.account, CREDENTIAL.hosts[0], CREDENTIAL.service))
+        .to.be.rejectedWith(/No auth found|No credentials found/)
     })
   })
 
@@ -113,34 +121,29 @@ describe('credential-manager acceptance', function () {
       delete process.env.HEROKU_NETRC_WRITE
     })
 
-    afterEach(function () {
-      cleanupCredentialStore()
+    afterEach(async function () {
+      await cleanupCredentialStore()
     })
 
-    // We save with `hosts = []` to test the keychain-only path
     it('saves and retrieves an entry', async function () {
-      await saveAuth(CREDENTIAL.account, CREDENTIAL.token, [], CREDENTIAL.service)
+      await saveAuth(CREDENTIAL.account, CREDENTIAL.token, CREDENTIAL.hosts, CREDENTIAL.service)
 
-      const auth = await getAuth(CREDENTIAL.account, 'missing.host.example.com', CREDENTIAL.service)
+      const auth = await getAuth(CREDENTIAL.account, CREDENTIAL.hosts[0], CREDENTIAL.service)
       expect(auth).to.deep.equal({account: CREDENTIAL.account, token: CREDENTIAL.token})
     })
 
     it('removes an entry', async function () {
-      // suppressing the keychain warning message since it is not relevant to this test
-      process.env.HEROKU_KEYCHAIN_WARNINGS = 'off'
-      await saveAuth(CREDENTIAL.account, CREDENTIAL.token, [], CREDENTIAL.service)
-      await removeAuth(CREDENTIAL.account, [], CREDENTIAL.service)
+      await saveAuth(CREDENTIAL.account, CREDENTIAL.token, CREDENTIAL.hosts, CREDENTIAL.service)
+      await removeAuth(CREDENTIAL.account, CREDENTIAL.hosts, CREDENTIAL.service)
 
-      await expect(getAuth(CREDENTIAL.account, 'missing.host.example.com', CREDENTIAL.service)).to.be.rejectedWith(/No auth found|No credentials found/)
-
-      delete process.env.HEROKU_KEYCHAIN_WARNINGS
+      await expect(getAuth(CREDENTIAL.account, CREDENTIAL.hosts[0], CREDENTIAL.service)).to.be.rejectedWith(/No auth found|No credentials found/)
     })
 
     it('updates entry when account already has credentials', async function () {
-      await saveAuth(CREDENTIAL.account, CREDENTIAL.token, [], CREDENTIAL.service)
-      await saveAuth(CREDENTIAL.account, 'new-token', [], CREDENTIAL.service)
+      await saveAuth(CREDENTIAL.account, CREDENTIAL.token, CREDENTIAL.hosts, CREDENTIAL.service)
+      await saveAuth(CREDENTIAL.account, 'new-token', CREDENTIAL.hosts, CREDENTIAL.service)
 
-      const auth = await getAuth(CREDENTIAL.account, 'missing.host.example.com', CREDENTIAL.service)
+      const auth = await getAuth(CREDENTIAL.account, CREDENTIAL.hosts[0], CREDENTIAL.service)
       expect(auth).to.deep.equal({account: CREDENTIAL.account, token: 'new-token'})
     })
 
@@ -148,15 +151,30 @@ describe('credential-manager acceptance', function () {
       const accountA = CREDENTIAL.account
       const accountB = `second-${accountA}`
 
-      await saveAuth(accountA, CREDENTIAL.token, [], CREDENTIAL.service)
-      await saveAuth(accountB, CREDENTIAL.token, [], CREDENTIAL.service)
-      await saveAuth(CREDENTIAL_ALTERNATE_SERVICE.account, CREDENTIAL_ALTERNATE_SERVICE.token, [], CREDENTIAL_ALTERNATE_SERVICE.service)
+      await saveAuth(accountA, CREDENTIAL.token, CREDENTIAL.hosts, CREDENTIAL.service)
+      await saveAuth(accountB, CREDENTIAL.token, CREDENTIAL.hosts, CREDENTIAL.service)
+      await saveAuth(CREDENTIAL_ALTERNATE_SERVICE.account, CREDENTIAL_ALTERNATE_SERVICE.token, CREDENTIAL_ALTERNATE_SERVICE.hosts, CREDENTIAL_ALTERNATE_SERVICE.service)
 
-      const {accounts} = listCredentialStoreAccounts(CREDENTIAL.service)
+      const accounts = await listKeychainAccounts(CREDENTIAL.service)
       expect(accounts).to.have.lengthOf(2)
       expect(accounts).to.include(accountA)
       expect(accounts).to.include(accountB)
       expect(accounts).to.not.include(CREDENTIAL_ALTERNATE_SERVICE.account)
+    })
+
+    it('skips netrc', async function () {
+      let netrcHasCredentials = false
+      await saveAuth(CREDENTIAL.account, CREDENTIAL.token, CREDENTIAL.hosts, CREDENTIAL.service)
+
+      const netrc = new Netrc()
+      await netrc.load()
+      for (const host of CREDENTIAL.hosts) {
+        if (netrc.machines[host]) {
+          netrcHasCredentials = true
+        }
+      }
+
+      expect(netrcHasCredentials).to.be.false
     })
   })
 
@@ -166,37 +184,23 @@ describe('credential-manager acceptance', function () {
     })
 
     afterEach(async function () {
-      cleanupCredentialStore()
+      await cleanupCredentialStore()
       await cleanupDefaultNetrc()
     })
 
-    it('saves/retrieves via credential store and netrc', async function () {
-      await saveAuth(CREDENTIAL.account, CREDENTIAL.token, CREDENTIAL.hosts, CREDENTIAL.service)
-
-      const keychainAuth = await getAuth(CREDENTIAL.account, 'missing.host.example.com', CREDENTIAL.service)
-      const netrcAuth = await getAuth('missing-account@example.com', CREDENTIAL.hosts[0], CREDENTIAL.service)
-
-      const expected = {account: CREDENTIAL.account, token: CREDENTIAL.token}
-      expect(keychainAuth).to.deep.equal(expected)
-      expect(netrcAuth).to.deep.equal(expected)
-    })
-
-    it('removes via credential store and netrc', async function () {
-      await saveAuth(CREDENTIAL.account, CREDENTIAL.token, CREDENTIAL.hosts, CREDENTIAL.service)
-      await removeAuth(CREDENTIAL.account, CREDENTIAL.hosts, CREDENTIAL.service)
-
-      await expect(getAuth(CREDENTIAL.account, CREDENTIAL.hosts[0], CREDENTIAL.service))
-        .to.be.rejectedWith(/No auth found|No credentials found/)
-    })
-
-    it('removes native store when logout runs with HEROKU_NETRC_WRITE after dual-path login', async function () {
-      delete process.env.HEROKU_NETRC_WRITE
-      await saveAuth(CREDENTIAL.account, CREDENTIAL.token, CREDENTIAL.hosts, CREDENTIAL.service)
-
+    it('removes from both stores when switching from netrc mode to keychain mode', async function () {
+      // Login in netrc mode
       process.env.HEROKU_NETRC_WRITE = 'TRUE'
-      await removeAuth(CREDENTIAL.account, CREDENTIAL.hosts, CREDENTIAL.service)
+      await saveAuth(CREDENTIAL.account, CREDENTIAL.token, CREDENTIAL.hosts, CREDENTIAL.service)
       delete process.env.HEROKU_NETRC_WRITE
 
+      // Login in keychain mode (writes to keychain, old netrc credential remains)
+      await saveAuth(CREDENTIAL.account, CREDENTIAL.token, CREDENTIAL.hosts, CREDENTIAL.service)
+
+      // Logout should clean both stores
+      await removeAuth(CREDENTIAL.account, CREDENTIAL.hosts, CREDENTIAL.service)
+
+      // Verify both stores are cleaned
       await expect(getAuth(CREDENTIAL.account, CREDENTIAL.hosts[0], CREDENTIAL.service))
         .to.be.rejectedWith(/No auth found|No credentials found/)
     })
@@ -218,37 +222,6 @@ describe('credential-manager acceptance', function () {
       } finally {
         fakeSetup?.cleanup()
       }
-    })
-
-    it('retrieves via netrc when credential store fails', async function () {
-      await saveAuth(CREDENTIAL.account, CREDENTIAL.token, CREDENTIAL.hosts, CREDENTIAL.service)
-
-      const netrcAuth = await getAuth('missing-account@example.com', CREDENTIAL.hosts[0], CREDENTIAL.service)
-      expect(netrcAuth).to.deep.equal({account: CREDENTIAL.account, token: CREDENTIAL.token})
-    })
-
-    it('removes via netrc when credential store fails', async function () {
-      await saveAuth(CREDENTIAL.account, CREDENTIAL.token, CREDENTIAL.hosts, CREDENTIAL.service)
-      await removeAuth('missing-account@example.com', CREDENTIAL.hosts, CREDENTIAL.service)
-
-      await expect(getAuth('missing-account@example.com', CREDENTIAL.hosts[0], CREDENTIAL.service))
-        .to.be.rejectedWith(/No auth found|No credentials found/)
-    })
-
-    it('retrieves via netrc when account is undefined and no accounts are found', async function () {
-      await saveAuth(CREDENTIAL.account, CREDENTIAL.token, CREDENTIAL.hosts, CREDENTIAL.service)
-      await removeAuth(CREDENTIAL.account, [], CREDENTIAL.service)
-
-      const netrcAuth = await getAuth(undefined, CREDENTIAL.hosts[0], CREDENTIAL.service)
-      expect(netrcAuth).to.deep.equal({account: CREDENTIAL.account, token: CREDENTIAL.token})
-    })
-
-    it('removes via netrc when account is undefined', async function () {
-      await saveAuth(CREDENTIAL.account, CREDENTIAL.token, CREDENTIAL.hosts, CREDENTIAL.service)
-      await removeAuth(undefined, CREDENTIAL.hosts, CREDENTIAL.service)
-
-      await expect(getAuth('missing-account@example.com', CREDENTIAL.hosts[0], CREDENTIAL.service))
-        .to.be.rejectedWith(/No auth found|No credentials found/)
     })
 
     it('errors when credentials are missing from credential store and netrc', async function () {

--- a/test/credential-manager/helpers/acceptance-utils.test.ts
+++ b/test/credential-manager/helpers/acceptance-utils.test.ts
@@ -15,7 +15,6 @@ import {
   isPowerShellAvailable,
   isSecretToolAvailable,
   isSecurityAvailable,
-  listCredentialStoreAccounts,
   SERVICE_NAME,
   setupFakeCredentialStore,
   skipUnlessAcceptance,
@@ -80,30 +79,6 @@ describe('acceptance utils', function () {
     })
   })
 
-  describe('listCredentialStoreAccounts', function () {
-    beforeEach(function () {
-      sinon.stub(process, 'platform').value('darwin')
-      sinon.stub(process, 'env').value({...process.env})
-    })
-
-    it('returns an empty list when credential store is disabled', function () {
-      process.env.HEROKU_NETRC_WRITE = 'true'
-
-      const result = listCredentialStoreAccounts(SERVICE_NAME)
-      expect(result).to.deep.equal({accounts: []})
-    })
-
-    it('returns handler and accounts when credential store is enabled', function () {
-      delete process.env.HEROKU_NETRC_WRITE
-      sinon.stub(MacOSHandler.prototype, 'listAccounts').returns(['test@example.com'])
-
-      const result = listCredentialStoreAccounts(SERVICE_NAME)
-
-      expect(result.handler).to.be.instanceOf(MacOSHandler)
-      expect(result.accounts).to.deep.equal(['test@example.com'])
-    })
-  })
-
   describe('cleanupCredentialStore', function () {
     let listAccountsStub: sinon.SinonStub
     let removeAuthStub: sinon.SinonStub
@@ -116,20 +91,20 @@ describe('acceptance utils', function () {
       removeAuthStub = sinon.stub(MacOSHandler.prototype, 'removeAuth')
     })
 
-    it('is a no-op when credential store is disabled', function () {
+    it('is a no-op when HEROKU_NETRC_WRITE is true', async function () {
       process.env.HEROKU_NETRC_WRITE = 'true'
 
-      expect(() => cleanupCredentialStore()).to.not.throw()
+      await expect(cleanupCredentialStore()).to.not.be.rejected
       expect(listAccountsStub.notCalled).to.equal(true)
       expect(removeAuthStub.notCalled).to.equal(true)
     })
 
-    it('removes all accounts for all fixture services', function () {
+    it('removes all accounts for all fixture services', async function () {
       delete process.env.HEROKU_NETRC_WRITE
       listAccountsStub.withArgs(SERVICE_NAME).returns(['test@example.com', 'second@example.com'])
       listAccountsStub.withArgs(ALTERNATE_SERVICE_NAME).returns(['third@example.com'])
 
-      cleanupCredentialStore()
+      await cleanupCredentialStore()
 
       expect(removeAuthStub.callCount).to.equal(3)
       expect(removeAuthStub.calledWith('test@example.com', SERVICE_NAME)).to.equal(true)
@@ -137,11 +112,11 @@ describe('acceptance utils', function () {
       expect(removeAuthStub.calledWith('third@example.com', ALTERNATE_SERVICE_NAME)).to.equal(true)
     })
 
-    it('does nothing when there are no accounts to remove', function () {
+    it('does nothing when there are no accounts to remove', async function () {
       delete process.env.HEROKU_NETRC_WRITE
       listAccountsStub.returns([])
 
-      cleanupCredentialStore()
+      await cleanupCredentialStore()
       expect(removeAuthStub.notCalled).to.equal(true)
     })
   })

--- a/test/credential-manager/helpers/acceptance-utils.ts
+++ b/test/credential-manager/helpers/acceptance-utils.ts
@@ -3,7 +3,7 @@ import {execSync} from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
 
-import {getCredentialHandler, getStorageConfig} from '../../../src/credential-manager-core/index.js'
+import {listKeychainAccounts, removeAuth} from '../../../src/credential-manager-core/index.js'
 import {Netrc} from '../../../src/credential-manager-core/lib/netrc-parser.js'
 
 export type AcceptanceFixture = {
@@ -68,15 +68,17 @@ export async function cleanupDefaultNetrc(): Promise<void> {
 /**
  * Removes all accounts for the provided test service from the platform-native credential store.
  */
-export function cleanupCredentialStore(): void {
+export async function cleanupCredentialStore(): Promise<void> {
   const services = getAllAcceptanceServices()
   for (const service of services) {
-    const {accounts, handler} = listCredentialStoreAccounts(service)
-    if (!handler) return
+    /* eslint-disable no-await-in-loop */
+    const accounts = await listKeychainAccounts(service)
+    if (accounts.length === 0) continue
 
     for (const account of accounts) {
-      handler.removeAuth(account, service)
+      await removeAuth(account, [], service)
     }
+    /* eslint-enable no-await-in-loop */
   }
 }
 
@@ -92,20 +94,6 @@ export function getAllAcceptanceHosts(): string[] {
  */
 export function getAllAcceptanceServices(): string[] {
   return [...new Set(Object.values(CREDENTIAL_FIXTURES).map(fixture => fixture.service))]
-}
-
-/**
- * Lists all accounts for the provided test service from the platform-native credential store.
- */
-export function listCredentialStoreAccounts(service: string) {
-  const {credentialStore} = getStorageConfig()
-
-  if (!credentialStore) return {accounts: []}
-
-  const handler = getCredentialHandler(credentialStore)
-  const accounts = handler.listAccounts(service)
-
-  return {accounts, handler}
 }
 
 /**

--- a/test/credential-manager/index.test.ts
+++ b/test/credential-manager/index.test.ts
@@ -22,7 +22,6 @@ describe('credential-manager', function () {
     sinon.stub(process, 'env').value(env)
 
     delete env.HEROKU_NETRC_WRITE
-    delete env.HEROKU_NATIVE_STORE_WRITE
   })
 
   afterEach(function () {
@@ -30,7 +29,7 @@ describe('credential-manager', function () {
   })
 
   describe('saveAuth', function () {
-    it('should save to both credential store and netrc', async function () {
+    it('should save to credential store only', async function () {
       const macosStub = sinon.stub(MacOSHandler.prototype, 'saveAuth')
       const netrcStub = sinon.stub(NetrcHandler.prototype, 'saveAuthForHosts').resolves()
 
@@ -42,15 +41,10 @@ describe('credential-manager', function () {
         service: 'heroku-cli',
         token: 'test-token',
       })
-      expect(netrcStub.calledOnce).to.be.true
-      expect(netrcStub.firstCall.args[0]).to.deep.equal({
-        login: 'user@example.com',
-        password: 'test-token',
-      })
-      expect(netrcStub.firstCall.args[1]).to.deep.equal(['api.heroku.com'])
+      expect(netrcStub.notCalled).to.be.true
     })
 
-    it('should save to netrc-only when credential store is disabled', async function () {
+    it('should save to netrc-only when HEROKU_NETRC_WRITE is true', async function () {
       process.env.HEROKU_NETRC_WRITE = 'TRUE'
       const macosStub = sinon.stub(MacOSHandler.prototype, 'saveAuth')
       const netrcStub = sinon.stub(NetrcHandler.prototype, 'saveAuthForHosts').resolves()
@@ -61,30 +55,7 @@ describe('credential-manager', function () {
       expect(netrcStub.calledOnce).to.be.true
     })
 
-    it('should save to native store only when HEROKU_NATIVE_STORE_WRITE is true', async function () {
-      process.env.HEROKU_NATIVE_STORE_WRITE = 'true'
-      const macosStub = sinon.stub(MacOSHandler.prototype, 'saveAuth')
-      const netrcStub = sinon.stub(NetrcHandler.prototype, 'saveAuthForHosts').resolves()
-
-      await credentialManager.saveAuth('user@example.com', 'test-token', ['api.heroku.com'])
-
-      expect(macosStub.calledOnce).to.be.true
-      expect(netrcStub.notCalled).to.be.true
-    })
-
-    it('should save to both when HEROKU_NETRC_WRITE and HEROKU_NATIVE_STORE_WRITE are true', async function () {
-      process.env.HEROKU_NETRC_WRITE = 'TRUE'
-      process.env.HEROKU_NATIVE_STORE_WRITE = 'TRUE'
-      const macosStub = sinon.stub(MacOSHandler.prototype, 'saveAuth')
-      const netrcStub = sinon.stub(NetrcHandler.prototype, 'saveAuthForHosts').resolves()
-
-      await credentialManager.saveAuth('user@example.com', 'test-token', ['api.heroku.com'])
-
-      expect(macosStub.calledOnce).to.be.true
-      expect(netrcStub.calledOnce).to.be.true
-    })
-
-    it('should continue to netrc if credential store fails', async function () {
+    it('should fall back to netrc if credential store fails', async function () {
       const macosStub = sinon.stub(MacOSHandler.prototype, 'saveAuth').throws(new Error('Keychain error'))
       const netrcStub = sinon.stub(NetrcHandler.prototype, 'saveAuthForHosts').resolves()
 
@@ -94,19 +65,8 @@ describe('credential-manager', function () {
       expect(netrcStub.calledOnce).to.be.true
     })
 
-    it('should save to credential store once and netrc once for multiple hosts', async function () {
-      const macosStub = sinon.stub(MacOSHandler.prototype, 'saveAuth')
-      const netrcStub = sinon.stub(NetrcHandler.prototype, 'saveAuthForHosts').resolves()
-
-      await credentialManager.saveAuth('user@example.com', 'test-token', ['api.heroku.com', 'git.heroku.com'])
-
-      expect(macosStub.calledOnce).to.be.true
-      expect(netrcStub.calledOnce).to.be.true
-      expect(netrcStub.firstCall.args[1]).to.deep.equal(['api.heroku.com', 'git.heroku.com'])
-    })
-
-    it('should throw an error when netrc fails to save', async function () {
-      const macosStub = sinon.stub(MacOSHandler.prototype, 'saveAuth')
+    it('should throw an error when netrc fallback fails', async function () {
+      const macosStub = sinon.stub(MacOSHandler.prototype, 'saveAuth').throws(new Error('Keychain error'))
       const netrcStub = sinon.stub(NetrcHandler.prototype, 'saveAuthForHosts').throws(new Error('Netrc error'))
 
       await expect(credentialManager.saveAuth('user@example.com', 'test-token', ['api.heroku.com']))
@@ -117,7 +77,7 @@ describe('credential-manager', function () {
 
     it('should save to credential store with custom service name', async function () {
       const macosStub = sinon.stub(MacOSHandler.prototype, 'saveAuth')
-      sinon.stub(NetrcHandler.prototype, 'saveAuthForHosts').resolves()
+      const netrcStub = sinon.stub(NetrcHandler.prototype, 'saveAuthForHosts').resolves()
 
       await credentialManager.saveAuth('user@example.com', 'test-token', ['api.heroku.com'], 'custom-service')
 
@@ -126,6 +86,7 @@ describe('credential-manager', function () {
         service: 'custom-service',
         token: 'test-token',
       })
+      expect(netrcStub.notCalled).to.be.true
     })
   })
 
@@ -143,7 +104,7 @@ describe('credential-manager', function () {
       expect(netrcStub.notCalled).to.be.true
     })
 
-    it('should retrieve from netrc-only when credential store is disabled', async function () {
+    it('should retrieve from netrc-only when HEROKU_NETRC_WRITE is true', async function () {
       process.env.HEROKU_NETRC_WRITE = 'TRUE'
       const macosStub = sinon.stub(MacOSHandler.prototype, 'getAuth')
       const netrcStub = sinon.stub(NetrcHandler.prototype, 'getAuth').resolves({login: 'user@example.com', password: 'netrc-token'})
@@ -154,31 +115,6 @@ describe('credential-manager', function () {
       expect(netrcStub.calledOnce).to.be.true
       expect(netrcStub.firstCall.args[0]).to.equal('api.heroku.com')
       expect(auth).to.deep.equal({account: 'user@example.com', token: 'netrc-token'})
-    })
-
-    it('should retrieve from native store only when HEROKU_NATIVE_STORE_WRITE is true', async function () {
-      process.env.HEROKU_NATIVE_STORE_WRITE = 'true'
-      const macosStub = sinon.stub(MacOSHandler.prototype, 'getAuth').returns('keychain-token')
-      const netrcStub = sinon.stub(NetrcHandler.prototype, 'getAuth')
-
-      const auth = await credentialManager.getAuth('user@example.com', 'api.heroku.com')
-
-      expect(macosStub.calledOnce).to.be.true
-      expect(netrcStub.notCalled).to.be.true
-      expect(auth).to.deep.equal({account: 'user@example.com', token: 'keychain-token'})
-    })
-
-    it('should not fall back to netrc when HEROKU_NATIVE_STORE_WRITE is true and native store fails', async function () {
-      process.env.HEROKU_NATIVE_STORE_WRITE = 'true'
-      const macosStub = sinon.stub(MacOSHandler.prototype, 'getAuth').throws(new Error('Keychain error'))
-      const netrcStub = sinon.stub(NetrcHandler.prototype, 'getAuth')
-
-      stderr.start()
-      await expect(credentialManager.getAuth('user@example.com', 'api.heroku.com')).to.be.rejectedWith(Error, 'No auth found')
-      stderr.stop()
-
-      expect(macosStub.calledOnce).to.be.true
-      expect(netrcStub.notCalled).to.be.true
     })
 
     it('should fall back to netrc if credential store fails', async function () {
@@ -258,31 +194,8 @@ describe('credential-manager', function () {
       expect(netrcStub.firstCall.args[0]).to.deep.equal(['api.heroku.com'])
     })
 
-    it('should still remove from native store when HEROKU_NETRC_WRITE disables save path', async function () {
+    it('should remove from both stores even when HEROKU_NETRC_WRITE is true', async function () {
       process.env.HEROKU_NETRC_WRITE = 'TRUE'
-      const macosStub = sinon.stub(MacOSHandler.prototype, 'removeAuth')
-      const netrcStub = sinon.stub(NetrcHandler.prototype, 'removeAuthForHosts').resolves()
-
-      await credentialManager.removeAuth('user@example.com', ['api.heroku.com'])
-
-      expect(macosStub.calledOnce).to.be.true
-      expect(netrcStub.calledOnce).to.be.true
-    })
-
-    it('should remove from native store only when HEROKU_NATIVE_STORE_WRITE is true', async function () {
-      process.env.HEROKU_NATIVE_STORE_WRITE = 'true'
-      const macosStub = sinon.stub(MacOSHandler.prototype, 'removeAuth')
-      const netrcStub = sinon.stub(NetrcHandler.prototype, 'removeAuthForHosts').resolves()
-
-      await credentialManager.removeAuth('user@example.com', ['api.heroku.com'])
-
-      expect(macosStub.calledOnce).to.be.true
-      expect(netrcStub.notCalled).to.be.true
-    })
-
-    it('should remove from both when HEROKU_NETRC_WRITE and HEROKU_NATIVE_STORE_WRITE are true', async function () {
-      process.env.HEROKU_NETRC_WRITE = 'TRUE'
-      process.env.HEROKU_NATIVE_STORE_WRITE = 'TRUE'
       const macosStub = sinon.stub(MacOSHandler.prototype, 'removeAuth')
       const netrcStub = sinon.stub(NetrcHandler.prototype, 'removeAuthForHosts').resolves()
 

--- a/test/credential-manager/lib/credential-storage-selector.test.ts
+++ b/test/credential-manager/lib/credential-storage-selector.test.ts
@@ -13,7 +13,6 @@ describe('credential-storage-selector', function () {
       const env = {...process.env}
       sinon.stub(process, 'env').value(env)
       delete env.HEROKU_NETRC_WRITE
-      delete env.HEROKU_NATIVE_STORE_WRITE
     })
 
     afterEach(function () {
@@ -30,20 +29,8 @@ describe('credential-storage-selector', function () {
       expect(result.useNetrc).to.be.true
     })
 
-    it('should return native + netrc when HEROKU_NETRC_WRITE and HEROKU_NATIVE_STORE_WRITE are true', function () {
+    it('should return macOS Keychain without netrc for darwin platform', function () {
       platformStub.value('darwin')
-      process.env.HEROKU_NETRC_WRITE = 'TRUE'
-      process.env.HEROKU_NATIVE_STORE_WRITE = 'TRUE'
-
-      const result = getStorageConfig()
-
-      expect(result.credentialStore).to.equal(CredentialStore.MacOSKeychain)
-      expect(result.useNetrc).to.be.true
-    })
-
-    it('should return native without netrc when HEROKU_NATIVE_STORE_WRITE is true', function () {
-      platformStub.value('darwin')
-      process.env.HEROKU_NATIVE_STORE_WRITE = 'TRUE'
 
       const result = getStorageConfig()
 
@@ -51,25 +38,16 @@ describe('credential-storage-selector', function () {
       expect(result.useNetrc).to.be.false
     })
 
-    it('should return macOS Keychain + netrc for darwin platform', function () {
-      platformStub.value('darwin')
-
-      const result = getStorageConfig()
-
-      expect(result.credentialStore).to.equal(CredentialStore.MacOSKeychain)
-      expect(result.useNetrc).to.be.true
-    })
-
-    it('should return Windows Credential Manager + netrc for win32 platform', function () {
+    it('should return Windows Credential Manager without netrc for win32 platform', function () {
       platformStub.value('win32')
 
       const result = getStorageConfig()
 
       expect(result.credentialStore).to.equal(CredentialStore.WindowsCredentialManager)
-      expect(result.useNetrc).to.be.true
+      expect(result.useNetrc).to.be.false
     })
 
-    it('should return Linux Secret Service + netrc when secret-tool is available', function () {
+    it('should return Linux Secret Service without netrc when secret-tool is available', function () {
       platformStub.value('linux')
 
       const execSyncStub = sinon.stub(childProcess, 'execSync')
@@ -78,7 +56,7 @@ describe('credential-storage-selector', function () {
       const result = getStorageConfig()
 
       expect(result.credentialStore).to.equal(CredentialStore.LinuxSecretService)
-      expect(result.useNetrc).to.be.true
+      expect(result.useNetrc).to.be.false
     })
 
     it('should return netrc-only when secret-tool is not available', function () {
@@ -111,7 +89,6 @@ describe('credential-storage-selector', function () {
       const env = {...process.env}
       sinon.stub(process, 'env').value(env)
       delete env.HEROKU_NETRC_WRITE
-      delete env.HEROKU_NATIVE_STORE_WRITE
     })
 
     afterEach(function () {


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary
<!-- Brief description of the changes in this PR. -->
This PR removes dual-write behavior from the credential manager, ensuring tokens are stored in only one location at a time.

Previously, the credential manager wrote tokens to both the native keychain (macOS Keychain, Linux Secret Service, or Windows Credential Manager) and the `.netrc` file simultaneously. This PR changes the behavior to use keychain exclusively (when available), with `.netrc` as a fallback mechanism when keychain operations fail.

**Key changes:**
- Removed `HEROKU_NATIVE_STORE_WRITE` environment variable (testing-only flag, no longer needed)
- Modified `saveAuth()` to track keychain success and only fall back to `.netrc` when keychain is unavailable or fails
- Modified `getAuth()` to mirror the same fallback pattern
- Updated `removeAuth()` to always clean both stores regardless of current mode (removes stale tokens when users switch modes)
- Updated unit and acceptance tests

**Behavior after this change:**
- Default (macOS/Windows/Linux with secret-tool): Keychain-only, with automatic `.netrc` fallback on errors
- `HEROKU_NETRC_WRITE=true`: `.netrc`-only, keychain skipped entirely
- Platforms without keychain: `.netrc` automatically used as primary storage
- Logout: Always cleans both stores to remove stale credentials during mode switches

## Type of Change
### Breaking Changes (major semver update)
- [x] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [x] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**: 
<!-- Add any context/setup necessary for testing. -->

**Steps**:
1. Pull down this branch
2. `npm install && npm run build`
3. `heroku logout`
4. Test default behavior (keychain-only):
   - `npm run example login` — should log in without error
   - `npm run example whoami` — should output email without error
   - `HEROKU_NETRC_WRITE=true npm run example whoami` — should error not logged in
   - `npm run example logout` — should log out without error
   - `npm run example whoami` — should error not logged in
5. Test netrc override:
   - `HEROKU_NETRC_WRITE=true npm run example login` — should log in without error
   - `HEROKU_NETRC_WRITE=true npm run example whoami` — should output email without error
   - Check `Keychain Access` for a `heroku-cli` entry — should be empty
   - `HEROKU_NETRC_WRITE=true npm run example logout` — should log out without error
   - `HEROKU_NETRC_WRITE=true npm run example whoami` — should error not logged in

## Screenshots (if applicable)

## Related Issues
GUS work item: [W-22180921](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002YeypJYAR/view)
