### PR TITLE
feat: document HEROKU_APP env var in app flag --help (W-23597905)

### DIFF
--- a/src/flags/app.ts
+++ b/src/flags/app.ts
@@ -47,6 +47,7 @@ export const app = Flags.custom({
   },
 
   description: 'app to run command against',
+  env: 'HEROKU_APP',
 })
 
 export const remote = Flags.custom({


### PR DESCRIPTION
## Summary

- Adds `env: 'HEROKU_APP'` to the `app` flag definition in `src/flags/app.ts`
- When oclif flags declare an `env` property, the env var name appears in `--help` output as `[$HEROKU_APP]`, making it discoverable to users
- The `HEROKU_APP` env var was already consumed in `getDefaultApp()` — this change is **documentation only** and does not alter runtime behavior

## Why

Users have no way to discover `HEROKU_APP` from `--help` output. Adding `env: 'HEROKU_APP'` to the flag definition is the standard oclif mechanism for surfacing env var support in help text.

Fixes heroku/cli#1758 / GUS W-23597905

## Test plan

- [ ] All existing `test/flags/app.test.ts` tests pass (14/14)
- [ ] `npm run lint` passes on changed file
- [ ] Run any app-scoped command with `--help` and confirm `[$HEROKU_APP]` appears in the `--app` flag description

🤖 Generated with [Claude Code](https://claude.com/claude-code)