### PR TITLE
feat: handle 2FA prompts safely during CLI actions

### DIFF
--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -2,6 +2,7 @@ import type {Config} from '@oclif/core/interfaces'
 
 import {HTTP, HTTPError, HTTPRequestOptions} from '@heroku/http-call'
 import {CLIError, warn} from '@oclif/core/errors'
+import {ux} from '@oclif/core/ux'
 import debug from 'debug'
 import * as url from 'node:url'
 
@@ -425,20 +426,30 @@ export class APIClient {
   }
 
   twoFactorPrompt() {
+    if (!process.stdin.isTTY) {
+      return Promise.reject(new Error('Two-factor authentication requires an interactive terminal.'))
+    }
+
     yubikey.enable()
     return this.twoFactorMutex.synchronize(async () => {
       try {
-        const {factor} = await prompter.prompt<{factor: string}>([{
-          mask: '*',
-          message: 'Two-factor code',
-          name: 'factor',
-          type: 'password',
-        }])
+        const result = await ux.action.pauseAsync(async () => {
+          try {
+            const {factor} = await prompter.prompt<{factor: string}>([{
+              mask: '*',
+              message: 'Two-factor code',
+              name: 'factor',
+              type: 'password',
+            }])
+            return {factor}
+          } catch (error) {
+            return {error}
+          }
+        })
+        if ('error' in result) throw result.error
+        return result.factor
+      } finally {
         yubikey.disable()
-        return factor
-      } catch (error) {
-        yubikey.disable()
-        throw error
       }
     })
   }

--- a/test/api-client.test.ts
+++ b/test/api-client.test.ts
@@ -1,4 +1,5 @@
 import {Config} from '@oclif/core/config'
+import {ux} from '@oclif/core/ux'
 import debug from 'debug'
 import {expect, fancy} from 'fancy-test'
 import nock from 'nock'
@@ -14,6 +15,7 @@ const SYSTEM_TMPDIR = os.tmpdir()
 import {Command as CommandBase} from '../src/command.js'
 import {writeLoginState} from '../src/credential-manager-core/lib/login-state.js'
 import {setCredentialManagerProvider} from '../src/credential-manager.js'
+import {prompter} from '../src/prompter.js'
 import {RequestId, requestIdHeader} from '../src/request-id.js'
 import {restoreCredentialManagerStub, stubCredentialManager} from './helpers/credential-manager-stub.js'
 
@@ -802,7 +804,9 @@ describe('api_client', () => {
     .it('2fa preauth', async ctx => {
       const scope = nock('https://api.heroku.com')
       scope.get('/apps/myapp').reply(403, {app: {name: 'myapp'}, id: 'two_factor'})
-      scope.put('/apps/myapp/pre-authorizations').reply(200, {})
+      scope.get('/apps/myapp/config').reply(403, {app: {name: 'myapp'}, id: 'two_factor'})
+      scope.get('/apps/myapp/dynos').reply(403, {app: {name: 'myapp'}, id: 'two_factor'})
+      scope.put('/apps/myapp/pre-authorizations').matchHeader('Heroku-Two-Factor-Code', '123456').reply(200, {})
       scope.get('/apps/myapp').reply(200, {name: 'myapp'})
       scope.get('/apps/anotherapp').reply(200, {name: 'anotherapp'})
       scope.get('/apps/myapp/config').reply(200, {foo: 'bar'})
@@ -810,7 +814,7 @@ describe('api_client', () => {
 
       const cmd = new Command([], ctx.config)
       // Mock the twoFactorPrompt method
-      sinon.stub(cmd.heroku, 'twoFactorPrompt').resolves('123456')
+      const promptStub = sinon.stub(cmd.heroku, 'twoFactorPrompt').resolves('123456')
       const info = cmd.heroku.get('/apps/myapp')
       const anotherapp = cmd.heroku.get('/apps/anotherapp')
       const _config = cmd.heroku.get('/apps/myapp/config')
@@ -819,7 +823,72 @@ describe('api_client', () => {
       expect((await anotherapp).body).to.deep.equal({name: 'anotherapp'})
       expect((await _config).body).to.deep.equal({foo: 'bar'})
       expect((await dynos).body).to.deep.equal({web: 1})
+      expect(promptStub.calledOnce).to.be.true
       scope.done()
+    })
+
+  test
+    .it('pauses an active action while prompting for 2fa', async ctx => {
+      const cmd = new Command([], ctx.config)
+      const originalIsTTY = process.stdin.isTTY
+      Object.defineProperty(process.stdin, 'isTTY', {configurable: true, value: true})
+      const promptStub = sinon.stub(prompter, 'prompt').resolves({factor: '123456'})
+      const pauseStub = sinon.stub(ux.action, 'pauseAsync').callsFake(async fn => {
+        expect(promptStub.called).to.be.false
+        const result = await fn()
+        expect(promptStub.calledOnce).to.be.true
+        return result
+      })
+
+      try {
+        expect(await cmd.heroku.twoFactorPrompt()).to.equal('123456')
+        expect(pauseStub.calledOnce).to.be.true
+        expect(promptStub.calledOnce).to.be.true
+      } finally {
+        pauseStub.restore()
+        promptStub.restore()
+        Object.defineProperty(process.stdin, 'isTTY', {configurable: true, value: originalIsTTY})
+      }
+    })
+
+  test
+    .it('rejects a 2fa prompt without an interactive terminal', async ctx => {
+      const cmd = new Command([], ctx.config)
+      const originalIsTTY = process.stdin.isTTY
+      Object.defineProperty(process.stdin, 'isTTY', {configurable: true, value: false})
+      const promptStub = sinon.stub(prompter, 'prompt')
+
+      try {
+        await expect(cmd.heroku.twoFactorPrompt()).to.be.rejectedWith('Two-factor authentication requires an interactive terminal.')
+        expect(promptStub.called).to.be.false
+      } finally {
+        promptStub.restore()
+        Object.defineProperty(process.stdin, 'isTTY', {configurable: true, value: originalIsTTY})
+      }
+    })
+
+  test
+    .it('resumes the action before propagating a 2fa prompt error', async ctx => {
+      const cmd = new Command([], ctx.config)
+      const originalIsTTY = process.stdin.isTTY
+      Object.defineProperty(process.stdin, 'isTTY', {configurable: true, value: true})
+      const promptStub = sinon.stub(prompter, 'prompt').rejects(new Error('Two-factor prompt canceled'))
+      let pauseCallbackCompleted = false
+      const pauseStub = sinon.stub(ux.action, 'pauseAsync').callsFake(async fn => {
+        const result = await fn()
+        pauseCallbackCompleted = true
+        return result
+      })
+
+      try {
+        await expect(cmd.heroku.twoFactorPrompt()).to.be.rejectedWith('Two-factor prompt canceled')
+        expect(pauseCallbackCompleted).to.be.true
+        expect(pauseStub.calledOnce).to.be.true
+      } finally {
+        pauseStub.restore()
+        promptStub.restore()
+        Object.defineProperty(process.stdin, 'isTTY', {configurable: true, value: originalIsTTY})
+      }
     })
 
   context('with HEROKU_DEBUG = "1"', function () {


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary

This is part of a two-step change to fix a recent bug with paranoid apps and Claude.  The second part of this fix will be in the CLI after this is accepted.

Why:

2FA prompts could hang in noninteractive sessions or leave active oclif actions paused after cancellation.

The surface area for this change is ONLY paranoid apps (Heroku apps).  That said, I plan to test this for all commands in the blast radius in the CLI PR later.

What:
- Reject 2FA challenges when stdin is not a TTY
- Wrap interactive prompts with ux.action.pauseAsync()
- Convert prompt rejection to a resolved result so oclif resumes the action before the error is rethrown
- Keep the mutex and shared preauthorization promise behavior for concurrent requests

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [x] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing

CI testing is fine

## Related Issues
GUS work item: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002bIDdzYAG/view
